### PR TITLE
Moved match! function definition to the bottom 

### DIFF
--- a/src/tries.jl
+++ b/src/tries.jl
@@ -82,6 +82,19 @@ end
 
 lower(c::UInt8) = UInt8('A') <= c <= UInt8('Z') ? c | 0x20 : c 
 
+"""
+    Parsers.match!(t::Parsers.Trie, io::IO, r::Parsers.Result, setvalue::Bool=true, ignorecase::Bool=false)
+
+    Function that takes an `io::IO` argument, a prebuilt `r::Parsers.Result` argument, and a `t::Parsers.Trie` argument, and attempts to match/detect special values in `t` with the next bytes consumed from `io`.
+    If special values are found, `r.result` will be set to the value that was associated with `t` when it was constructed.
+    The return value of `Parsers.match!` is if a special value was indeed detected in `io` (`true` or `false`).
+    Optionally, if the `setvalue` is `false`, `r.result` will be unaffected (i.e. not set) even if a special value is found.
+    The optional argument `ignorecase` can be used if case-insensitive matching is desired.
+
+    Note that `io` is reset to its original position if no special value is found.
+"""
+function match! end
+
 function generatebranches(leaves, isparentleaf, parentvalue, parentcode, parentb)
     leaf = leaves[1]
     ifblock = Expr(:if, :(b === $(label(leaf)) || (ignorecase && lower(b) === $(lower(label(leaf))))), generatebranch(leaf))
@@ -120,19 +133,6 @@ function generatebranch(::Type{Trie{label, leaf, value, code, L}}) where {label,
         $body
     end
 end
-
-"""
-    Parsers.match!(t::Parsers.Trie, io::IO, r::Parsers.Result, setvalue::Bool=true, ignorecase::Bool=false)
-
-    Function that takes an `io::IO` argument, a prebuilt `r::Parsers.Result` argument, and a `t::Parsers.Trie` argument, and attempts to match/detect special values in `t` with the next bytes consumed from `io`.
-    If special values are found, `r.result` will be set to the value that was associated with `t` when it was constructed.
-    The return value of `Parsers.match!` is if a special value was indeed detected in `io` (`true` or `false`).
-    Optionally, if the `setvalue` is `false`, `r.result` will be unaffected (i.e. not set) even if a special value is found.
-    The optional argument `ignorecase` can be used if case-insensitive matching is desired.
-
-    Note that `io` is reset to its original position if no special value is found.
-"""
-function match! end
 
 @generated function match!(root::Trie{label, leaf, value, code, L}, io::IO, r::Result, setvalue::Bool=true, ignorecase::Bool=false) where {label, leaf, value, code, L}
     isempty(L.parameters) && return :(return true)


### PR DESCRIPTION
Fixed world age issue when starting julia with `--compiled-modules=no`. Fixes https://github.com/JuliaData/CSV.jl/issues/309

Note: I only moved the declaration of `generatebranch(es)` before the `quote` but Github Files changed view is showing it all messy  