### PR TITLE
Add a newline keyword argument to the Delimited layer. Before, caller…

### DIFF
--- a/src/dates.jl
+++ b/src/dates.jl
@@ -1,24 +1,24 @@
 make(df::Dates.DateFormat) = df
 make(df::String) = Dates.DateFormat(df)
 
-@inline parse!(d::Delimited{ignore_repeated}, io::IO, r::Result{T}; kwargs...) where {ignore_repeated, T <: Dates.TimeType} =
-    parse!(d.next, io, r, d.delims, ignore_repeated; kwargs...)
-@inline parse!(q::Quoted, io::IO, r::Result{T}, delims=nothing, ignore_repeated=false; kwargs...) where {T <: Dates.TimeType} =
-    parse!(q.next, io, r, delims, ignore_repeated, q.openquotechar, q.closequotechar, q.escapechar, q.ignore_quoted_whitespace; kwargs...)
-@inline parse!(s::Strip, io::IO, r::Result{T}, delims=nothing, ignore_repeated=false, openquotechar=nothing, closequotechar=nothing, escapechar=nothing, ignore_quoted_whitespace=false; kwargs...) where {T <: Dates.TimeType} =
-    parse!(s.next, io, r, delims, ignore_repeated, openquotechar, closequotechar, escapechar, ignore_quoted_whitespace; kwargs...)
-@inline parse!(s::Sentinel, io::IO, r::Result{T}, delims=nothing, ignore_repeated=false, openquotechar=nothing, closequotechar=nothing, escapechar=nothing, ignore_quoted_whitespace=false; kwargs...) where {T <: Dates.TimeType} =
-    parse!(s.next, io, r, delims, ignore_repeated, openquotechar, closequotechar, escapechar, ignore_quoted_whitespace, s.sentinels; kwargs...)
-@inline parse!(::typeof(defaultparser), io::IO, r::Result{T}, delims=nothing, ignore_repeated=false, openquotechar=nothing, closequotechar=nothing, escapechar=nothing, ignore_quoted_whitespace=false, node=nothing; kwargs...) where {T <: Dates.TimeType} =
-    defaultparser(io, r, delims, ignore_repeated, openquotechar, closequotechar, escapechar, ignore_quoted_whitespace, node; kwargs...)
+@inline parse!(d::Delimited{ignorerepeated, newline}, io::IO, r::Result{T}; kwargs...) where {ignorerepeated, newline, T <: Dates.TimeType} =
+    parse!(d.next, io, r, d.delims, ignorerepeated, newline; kwargs...)
+@inline parse!(q::Quoted, io::IO, r::Result{T}, delims=nothing, ignorerepeated=false, newline=false; kwargs...) where {T <: Dates.TimeType} =
+    parse!(q.next, io, r, delims, ignorerepeated, newline, q.openquotechar, q.closequotechar, q.escapechar, q.ignore_quoted_whitespace; kwargs...)
+@inline parse!(s::Strip, io::IO, r::Result{T}, delims=nothing, ignorerepeated=false, newline=false, openquotechar=nothing, closequotechar=nothing, escapechar=nothing, ignore_quoted_whitespace=false; kwargs...) where {T <: Dates.TimeType} =
+    parse!(s.next, io, r, delims, ignorerepeated, newline, openquotechar, closequotechar, escapechar, ignore_quoted_whitespace; kwargs...)
+@inline parse!(s::Sentinel, io::IO, r::Result{T}, delims=nothing, ignorerepeated=false, newline=false, openquotechar=nothing, closequotechar=nothing, escapechar=nothing, ignore_quoted_whitespace=false; kwargs...) where {T <: Dates.TimeType} =
+    parse!(s.next, io, r, delims, ignorerepeated, newline, openquotechar, closequotechar, escapechar, ignore_quoted_whitespace, s.sentinels; kwargs...)
+@inline parse!(::typeof(defaultparser), io::IO, r::Result{T}, delims=nothing, ignorerepeated=false, newline=false, openquotechar=nothing, closequotechar=nothing, escapechar=nothing, ignore_quoted_whitespace=false, node=nothing; kwargs...) where {T <: Dates.TimeType} =
+    defaultparser(io, r, delims, ignorerepeated, newline, openquotechar, closequotechar, escapechar, ignore_quoted_whitespace, node; kwargs...)
 
 @inline function defaultparser(io::IO, r::Result{T},
-    delims=nothing, ignore_repeated=false, openquotechar=nothing, closequotechar=nothing,
+    delims=nothing, ignorerepeated=false, newline=false, openquotechar=nothing, closequotechar=nothing,
     escapechar=nothing, ignore_quoted_whitespace=false, node=nothing;
     dateformat::Union{String, Dates.DateFormat}=Dates.default_format(T),
     kwargs...) where {T <: Dates.TimeType}
     setfield!(r, 3, Int64(position(io)))
-    res = defaultparser(io, Result(String), delims, ignore_repeated, openquotechar, closequotechar, escapechar, ignore_quoted_whitespace, node)
+    res = defaultparser(io, Result(String), delims, ignorerepeated, newline, openquotechar, closequotechar, escapechar, ignore_quoted_whitespace, node)
     setfield!(r, 1, missing)
     code = res.code
     if ok(res.code)

--- a/src/tries.jl
+++ b/src/tries.jl
@@ -106,7 +106,6 @@ function generatebranches(leaves, isparentleaf, parentvalue, parentcode, parentb
         block = elseifblock
     end
     if isparentleaf
-        (parentb === UInt8('\n') || parentb === UInt8('\r')) && (parentcode |= NEWLINE)
         push!(block.args, :(value = $parentvalue; code = $parentcode; b = $parentb; @goto match))
     end
     return quote
@@ -117,7 +116,7 @@ end
 
 function generatebranch(::Type{Trie{label, leaf, value, code, L}}) where {label, leaf, value, code, L}
     leaves = L.parameters
-    c = (label === UInt8('\n') || label === UInt8('\r')) ? (code | NEWLINE) : code
+    c = code
     if isempty(leaves)
         body = :(value = $value; code = $c | ifelse(eof(io), EOF, SUCCESS); @goto match)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -267,22 +267,22 @@ r = Parsers.parse(Parsers.Delimited(), IOBuffer("1;"), Int)
 @test r.result === 1
 @test r.code === INVALID | EOF | OK | INVALID_DELIMITER
 @test r.pos == 0
-r = Parsers.parse(Parsers.Delimited(',', '\n'), IOBuffer("1\n"), Int)
+r = Parsers.parse(Parsers.Delimited(','; newline=true), IOBuffer("1\n"), Int)
 @test r.result === 1
-@test r.code === OK | DELIMITED | EOF | NEWLINE
+@test r.code === OK | EOF | NEWLINE
 @test r.pos == 0
-r = Parsers.parse(Parsers.Delimited(',', '\n'), IOBuffer("1abc\n"), Int)
+r = Parsers.parse(Parsers.Delimited(','; newline=true), IOBuffer("1abc\n"), Int)
 @test r.result === 1
-@test r.code === INVALID | OK | NEWLINE | EOF | INVALID_DELIMITER | DELIMITED
+@test r.code === INVALID | OK | NEWLINE | EOF | INVALID_DELIMITER
 @test r.pos == 0
-r = Parsers.parse(Parsers.Delimited(',', '\n'), IOBuffer("1abc"), Int)
+r = Parsers.parse(Parsers.Delimited(','; newline=true), IOBuffer("1abc"), Int)
 @test r.result === 1
 @test r.code === INVALID | OK | EOF | INVALID_DELIMITER
 @test r.pos == 0
 
-r = Parsers.parse(Parsers.Delimited(',', '\n', '\r', "\r\n"), IOBuffer("1\r2"), Int)
+r = Parsers.parse(Parsers.Delimited(','; newline=true), IOBuffer("1\r2"), Int)
 @test r.result === 1
-@test r.code === OK | DELIMITED | NEWLINE
+@test r.code === OK | NEWLINE
 @test r.pos == 0
 
 end # @testset
@@ -503,7 +503,7 @@ include("bools.jl")
 
 @testset "ignore repeated delimiters" begin
 
-let io=IOBuffer("1,,,2,null,4"), layers=Parsers.Delimited(Parsers.Quoted(Parsers.Sentinel(["null"])); ignore_repeated=true)
+let io=IOBuffer("1,,,2,null,4"), layers=Parsers.Delimited(Parsers.Quoted(Parsers.Sentinel(["null"])); ignorerepeated=true)
     r = Parsers.parse(layers, io, Int)
     @test r.result === 1
     @test r.code === OK | DELIMITED
@@ -522,7 +522,7 @@ let io=IOBuffer("1,,,2,null,4"), layers=Parsers.Delimited(Parsers.Quoted(Parsers
     @test r.pos == 11
 end
 
-let io=IOBuffer("1,,,2,null,4"), layers=Parsers.Delimited(Parsers.Quoted(Parsers.Sentinel(["null"])); ignore_repeated=true)
+let io=IOBuffer("1,,,2,null,4"), layers=Parsers.Delimited(Parsers.Quoted(Parsers.Sentinel(["null"])); ignorerepeated=true)
     r = Parsers.parse(layers, io, String)
     @test r.result === "1"
     @test r.code === OK | DELIMITED

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -155,12 +155,12 @@ r = Parsers.parse(Parsers.Delimited(), IOBuffer("1,"), String)
 r = Parsers.parse(Parsers.Delimited(), IOBuffer("1;"), String)
 @test r.result === "1;"
 @test r.code === OK | EOF
-r = Parsers.parse(Parsers.Delimited(',', '\n'), IOBuffer("1\n"), String)
+r = Parsers.parse(Parsers.Delimited(','; newline=true), IOBuffer("1\n"), String)
 @test r.result === "1"
-@test r.code === OK | EOF | DELIMITED | NEWLINE
-r = Parsers.parse(Parsers.Delimited(',', '\n'), IOBuffer("1abc\n"), String)
+@test r.code === OK | EOF | NEWLINE
+r = Parsers.parse(Parsers.Delimited(','; newline=true), IOBuffer("1abc\n"), String)
 @test r.result === "1abc"
-@test r.code === OK | EOF | DELIMITED | NEWLINE
+@test r.code === OK | EOF | NEWLINE
 
 end # @testset
 


### PR DESCRIPTION
…s could pass in \n themselves to count as a delimiter, but this wasn't ideal because if they used the ignorerepeated=true option, they probably only meant ignore repeated _delimiters_, not newlines. There are also use-cases where callers would like to check the result code for NEWLINE and not DELIMITED. That's the only change in behavior with this commit: before if Delimited matched a newline character, the return code was NEWLINE | DELIMITED, mainly because there wasn't a clean way of doing just one or the other. Now that we treat newlines special in Delimited, it's easy to mark the code as NEWLINE if we matched a NEWLINE instead of DELIMITED. This fixes https://github.com/JuliaData/CSV.jl/issues/326 by ensuring CSV doesn't overparse a row where the next row starts with the delimiter we're trying to ignore.