### PR TITLE
Add a noinline version of typeparser for floats, so the widened cases don't fully inline

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -1,6 +1,10 @@
 wider(::Type{Int64}) = Int128
 wider(::Type{Int128}) = BigInt
 
+# include a non-inlined version in case of widening (otherwise, all widened cases would fully inline)
+@noinline _typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, Q, debug, S, D, DF}, ::Type{IntType}) where {T <: AbstractFloat, ignorerepeated, Q, debug, S, D, DF, IntType} =
+    typeparse(T, source, pos, len, b, code, options, IntType)
+
 @inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, Q, debug, S, D, DF}, ::Type{IntType}=Int64) where {T <: AbstractFloat, ignorerepeated, Q, debug, S, D, DF, IntType}
     startpos = pos
     origb = b
@@ -152,7 +156,7 @@ wider(::Type{Int128}) = BigInt
         b > 0x09 && break
         if overflows(IntType) && digits > overflowval(IntType)
             fastseek!(source, startpos)
-            return typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
+            return _typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
         end
     end
     b += UInt8('0')
@@ -198,7 +202,7 @@ wider(::Type{Int128}) = BigInt
             b > 0x09 && break
             if overflows(IntType) && digits > overflowval(IntType)
                 fastseek!(source, startpos)
-                return typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
+                return _typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
             end
         end
     end
@@ -254,7 +258,7 @@ wider(::Type{Int128}) = BigInt
             end
             if overflows(IntType) && exp > overflowval(IntType)
                 fastseek!(source, startpos)
-                return typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
+                return _typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
             end
         end
     else

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -3,7 +3,7 @@ wider(::Type{Int128}) = BigInt
 
 # include a non-inlined version in case of widening (otherwise, all widened cases would fully inline)
 @noinline _typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, Q, debug, S, D, DF}, ::Type{IntType}) where {T <: AbstractFloat, ignorerepeated, Q, debug, S, D, DF, IntType} =
-    typeparse(T, source, pos, len, b, code, options, IntType)
+    typeparser(T, source, pos, len, b, code, options, IntType)
 
 @inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, Q, debug, S, D, DF}, ::Type{IntType}=Int64) where {T <: AbstractFloat, ignorerepeated, Q, debug, S, D, DF, IntType}
     startpos = pos


### PR DESCRIPTION
Leads to this improvement in compile times:
```julia
# before
julia> @time Parsers.parse(Float64, "1.0")
  2.006939 seconds (11.01 M allocations: 387.387 MiB, 12.40% gc time)
1.0

# after
julia> @time Parsers.parse(Float64, "1.0")
  0.410220 seconds (1.43 M allocations: 67.567 MiB, 6.65% gc time)
1.0
```