### PR TITLE
In roundQuotient, mod Int64 instead of using constructor to avoid Ine…

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -285,7 +285,7 @@ const bipows5 = [big(5)^x for x = 0:325]
 
 function roundQuotient(num, den)
     @inbounds quo, rem = MPZ.tdiv_qr!(QUOS[Threads.threadid()], REMS[Threads.threadid()], num, den)
-    q = Int64(quo)
+    q = quo % Int64
     cmpflg = cmp(MPZ.mul_2exp!(rem, 1), den)
     return ((q & 1) == 0 ? 1 == cmpflg : -1 < cmpflg) ? q + 1 : q
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -391,6 +391,9 @@ x, code, vpos, vlen, tlen = Parsers.xparse(String, "\"\"", 1, 2)
 # #38
 @test Parsers.parse(Date, "25JUL1985", Parsers.Options(dateformat="dduuuyyyy")) == Date(1985, 7, 25)
 
+# https://github.com/JuliaIO/JSON.jl/issues/296
+@test Parsers.parse(Float64, "99233885.0302231276962159466369304902338091026") === 9.923388503022313e7
+
 end # @testset "misc"
 
 include("floats.jl")


### PR DESCRIPTION
…xactError. Fixes https://github.com/JuliaIO/JSON.jl/issues/296