### PR TITLE
fix Int64 parse error in case close to overflow (#44)

### DIFF
--- a/src/ints.jl
+++ b/src/ints.jl
@@ -66,13 +66,11 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
         pos += 1
         incr!(source)
         if eof(source, pos, len)
-            x = ifelse(neg, -x, x)
             code |= OK | EOF
             @goto done
         end
         b = peekbyte(source, pos) - UInt8('0')
         if b > 0x09
-            x = ifelse(neg, -x, x)
             code |= OK
             @goto done
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,15 @@ end # @testset "Core Parsers.xparse"
     @test vlen == length(str)
 end
 
+# test some critical ints Issue #44
+for i in [typemin(Int64):typemin(Int64)+20; typemax(Int)-20:typemax(Int)]
+    str = string(i)
+    x, code, vpos, vlen, tlen = Parsers.xparse(Int64, str)
+    @test string(x) == str
+    @test code == OK | EOF
+    @test vlen == length(str)
+end
+
 end # @testset "ints"
 
 @testset "bools" begin


### PR DESCRIPTION
Fixes #44.

Method `Parsers.typeparser(Int64,...)` did not take into account, that the sign has already been
included in the resulting `x` in line `ints.jl:48`. 
