### PR TITLE
[BREAKING] Implement ignoreemptylines, commented line skipping, and ignorerepeated improvements

### DIFF
--- a/src/bools.jl
+++ b/src/bools.jl
@@ -1,4 +1,4 @@
-@inline function typeparser(::Type{Bool}, source, pos, len, b, code, options::Options{ignorerepeated, Q, debug, S, D, DF}) where {ignorerepeated, Q, debug, S, D, DF}
+@inline function typeparser(::Type{Bool}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
     x = false
     if debug
         println("start of Bool parsing")

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -1,4 +1,4 @@
-@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, Q, debug, S, D, DF}) where {T <: Dates.TimeType, ignorerepeated, Q, debug, S, D, DF}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: Dates.TimeType, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
     df = options.dateformat === nothing ? Dates.default_format(T) : options.dateformat
     ret = mytryparsenext_internal(T, source, Int(pos), len, df)
     if debug

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -2,10 +2,10 @@ wider(::Type{Int64}) = Int128
 wider(::Type{Int128}) = BigInt
 
 # include a non-inlined version in case of widening (otherwise, all widened cases would fully inline)
-@noinline _typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, Q, debug, S, D, DF}, ::Type{IntType}) where {T <: AbstractFloat, ignorerepeated, Q, debug, S, D, DF, IntType} =
+@noinline _typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, ::Type{IntType}) where {T <: AbstractFloat, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType} =
     typeparser(T, source, pos, len, b, code, options, IntType)
 
-@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, Q, debug, S, D, DF}, ::Type{IntType}=Int64) where {T <: AbstractFloat, ignorerepeated, Q, debug, S, D, DF, IntType}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, ::Type{IntType}=Int64) where {T <: AbstractFloat, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType}
     startpos = pos
     origb = b
     x = zero(T)

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -4,7 +4,7 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
 # if we eventually support non-base 10
 # overflowval(::Type{T}, base) where {T <: Integer} = div(typemax(T) - base + 1, base)
 
-@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, Q, debug, S, D, DF}) where {T <: Integer, ignorerepeated, Q, debug, S, D, DF}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: Integer, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
     x = zero(T)
     neg = false
     # start actual int parsing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,6 +154,32 @@ testcases = [
     (str="1a,,", kwargs=(ignorerepeated=true,), x=1, code=(OK | DELIMITED | INVALID_DELIMITER), vpos=1, vlen=2, tlen=4),
     (str="1a,,2", kwargs=(ignorerepeated=true,), x=1, code=(OK | DELIMITED | INVALID_DELIMITER), vpos=1, vlen=2, tlen=4),
     (str="1,\n", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | DELIMITED | NEWLINE | EOF), vpos=1, vlen=1, tlen=3),
+    (str="1,\n,", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=4),
+    (str="1,\n,\n", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=4),
+    (str="1::\n::", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=6),
+    (str="1::\n::\n", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=6),
+    (str="1,\r\n,", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=5),
+    (str="1,\r\n,\r\n", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=5),
+    (str="1::\r\n::", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=7),
+    (str="1::\r\n::\r\n", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=7),
+    # ignoreemptylines
+    (str="1\n\n", kwargs=(ignoreemptylines=true,), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=3),
+    (str="1\n\n\n", kwargs=(ignoreemptylines=true,), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=4),
+    (str="1,\n\n\n,", kwargs=(ignorerepeated=true, ignoreemptylines=true, delim=UInt8(',')), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=6),
+    (str="1::\n\n\n::", kwargs=(ignorerepeated=true, ignoreemptylines=true, delim="::"), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=8),
+    (str="1\r\n\r\n", kwargs=(ignoreemptylines=true,), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=5),
+    (str="1\r\n\r\n\r\n", kwargs=(ignoreemptylines=true,), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=7),
+    (str="1,\r\n\r\n\r\n,", kwargs=(ignorerepeated=true, ignoreemptylines=true, delim=UInt8(',')), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=9),
+    (str="1::\r\n\r\n\r\n::", kwargs=(ignorerepeated=true, ignoreemptylines=true, delim="::"), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=11),
+    # comments
+    (str="1\n#\n", kwargs=(comment="#",), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=4),
+    (str="1\n#   \n", kwargs=(comment="#",), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=7),
+    (str="1,\n#  \n\n,", kwargs=(ignorerepeated=true, ignoreemptylines=true, comment="#", delim=UInt8(',')), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=9),
+    (str="1::\n#  \n\n::", kwargs=(ignorerepeated=true, ignoreemptylines=true, comment="#", delim="::"), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=11),
+    (str="1\r\n#  \r\n", kwargs=(ignoreemptylines=true, comment="#",), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=8),
+    (str="1\r\n#  \r\n\r\n", kwargs=(ignoreemptylines=true, comment="#",), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=10),
+    (str="1,\r\n#  \r\n\r\n,", kwargs=(ignorerepeated=true, ignoreemptylines=true, comment="#", delim=UInt8(',')), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=12),
+    (str="1::\r\n#  \r\n\r\n::", kwargs=(ignorerepeated=true, ignoreemptylines=true, comment="#", delim="::"), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=14),
 ];
 
 for useio in (false, true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,6 +162,15 @@ testcases = [
     (str="1,\r\n,\r\n", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=5),
     (str="1::\r\n::", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=7),
     (str="1::\r\n::\r\n", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | DELIMITED | NEWLINE), vpos=1, vlen=1, tlen=7),
+    # invalid
+    (str="1a,\n,", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | INVALID_DELIMITER | DELIMITED | NEWLINE), vpos=1, vlen=2, tlen=5),
+    (str="1a,\n,\n", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | INVALID_DELIMITER | DELIMITED | NEWLINE), vpos=1, vlen=2, tlen=5),
+    (str="1a::\n::", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | INVALID_DELIMITER | DELIMITED | NEWLINE), vpos=1, vlen=2, tlen=7),
+    (str="1a::\n::\n", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | INVALID_DELIMITER | DELIMITED | NEWLINE), vpos=1, vlen=2, tlen=7),
+    (str="1a,\r\n,", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | INVALID_DELIMITER | DELIMITED | NEWLINE), vpos=1, vlen=2, tlen=6),
+    (str="1a,\r\n,\r\n", kwargs=(ignorerepeated=true, delim=UInt8(',')), x=1, code=(OK | INVALID_DELIMITER | DELIMITED | NEWLINE), vpos=1, vlen=2, tlen=6),
+    (str="1a::\r\n::", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | INVALID_DELIMITER | DELIMITED | NEWLINE), vpos=1, vlen=2, tlen=8),
+    (str="1a::\r\n::\r\n", kwargs=(ignorerepeated=true, delim="::"), x=1, code=(OK | INVALID_DELIMITER | DELIMITED | NEWLINE), vpos=1, vlen=2, tlen=8),
     # ignoreemptylines
     (str="1\n\n", kwargs=(ignoreemptylines=true,), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=3),
     (str="1\n\n\n", kwargs=(ignoreemptylines=true,), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=4),


### PR DESCRIPTION
This is basically a bunch of "parsing" functionality that CSV.jl
implemented/needed that should really live here instead. Here's a recap:

* `ignoreemptylines`: this allows skipping empty lines, this is done
when a newline is encountered, we immediately check if another line is
next and if so, consume it, and it will consume as many empty lines as
it encounters
* `comment`: this allows skipping "commented" lines that start with a
certain string; this check is also done after newlines are encountered,
hence internally, this is implemented as `checkcmtemptylines` where both
empty lines and commented lines are checked for simultaneously
* `ignorerepeated`: there was some missing functionality here in that
repeated delimiters that occurred _after_ a newline character weren't
consumed; this meant that CSV.jl needed to check at the start of each
row whether there were delimiters to ignore; the functionality
implemented here ensures that, because we treat newlines as a valid
delimiter, we continue consuming until we reach a non-delimiter or
newline