### PR TITLE
Don't treat "." as valid float

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -169,7 +169,7 @@ wider(::Type{Int128}) = BigInt
         incr!(source)
         if eof(source, pos, len)
             x = T(ifelse(neg, -digits, digits))
-            code |= OK | EOF
+            code |= ((startpos + 1) == pos ? INVALID : OK) | EOF
             @goto done
         end
         b = peekbyte(source, pos)

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -5,6 +5,7 @@ x, code, vpos, vlen, vlen = Parsers.xparse(Float64, "1x")
 testcases = [
     (str="", x=0.0, code=(INVALID | EOF), len=0, tot=0),
     (str="-", x=0.0, code=(INVALID | EOF), len=1, tot=1),
+    (str=".", x=0.0, code=(INVALID | EOF), len=1, tot=1),
     (str="1", x=1.0, code=(OK | EOF), len=1, tot=1),
     (str="+1", x=1.0, code=(OK | EOF), len=2, tot=2),
     (str="1.1", x=1.1, code=(OK | EOF), len=3, tot=3),


### PR DESCRIPTION
When encountering a decimal character and then immediately an EOF, we
were missing a check that we actually parsed any other digits and just
assumed parsing succeeded; this led to parsing "." as `0.0`. This PR
adds a check that if we saw decimal char and then EOF, if the decimal
char was the only byte consumed, then the value is invalid.

cc: @andreasnoack 