### PR TITLE
Ensure invalid dates follow Parsers error flow

### DIFF
--- a/src/dates.jl
+++ b/src/dates.jl
@@ -13,10 +13,16 @@
         code |= INVALID
     else
         values, pos = ret
-        x = T(values...)
-        code |= OK
-        if eof(source, pos, len)
-            code |= EOF
+        valid = Dates.validargs(T, values...)
+        if valid !== nothing
+            x = default(T)
+            code |= INVALID
+        else
+            x = T(values...)
+            code |= OK
+            if eof(source, pos, len)
+                code |= EOF
+            end
         end
     end
 

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -20,9 +20,9 @@
         else
             x = T(values...)
             code |= OK
-            if eof(source, pos, len)
-                code |= EOF
-            end
+        end
+        if eof(source, pos, len)
+            code |= EOF
         end
     end
 

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -87,6 +87,7 @@ end
                         @goto error
                     end
                     $name, pos = val
+                    $name = Int64($name)
                 end
                 num_parsed += 1
                 directive_index += 1

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -87,7 +87,9 @@ end
                         @goto error
                     end
                     $name, pos = val
-                    $name = Int64($name)
+                    if $name isa Integer
+                        $name = Int64($name)
+                    end
                 end
                 num_parsed += 1
                 directive_index += 1

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -62,4 +62,9 @@ x, code, vpos, vlen, tlen = Parsers.xparse(Date, "1,")
 @test Parsers.parse(DateTime, "1996/Feb/15", Parsers.Options(dateformat="yy/uuu/dd")) === DateTime(1996, 2, 15)
 @test Parsers.parse(DateTime, "1996, Jan, 15", Parsers.Options(dateformat="yyyy, uuu, dd")) === DateTime(1996, 1, 15)
 
+@test_throws Parsers.Error Parsers.parse(Date, "2020-05-32")
+@test_throws Parsers.Error Parsers.parse(DateTime, "2020-05-32")
+@test_throws Parsers.Error Parsers.parse(Time, "25:00:00")
+@test_throws Parsers.Error Parsers.parse(DateTime, "2020-05-05T00:00:60")
+
 end


### PR DESCRIPTION
This came up in a CSV.jl issue:
https://github.com/JuliaData/CSV.jl/issues/86#issuecomment-624022339,
where an error was being thrown while parsing due to an invalid date.
This breaks the error flow of CSV & Parsers which have their own
error handling stack and signal and handle invalid values without
throwing errors. In the automatic inference case of CSV.jl (where it
decides the types of columns itself while parsing), this should simply
promote the column to a String type. In Parsers with `Parsers.parse`, trying to parse an
invalid date should follow the same pattern as other types and throw a
`Parsers.Error` with the appropriate error codes set on the return code
instead of allowing the Dates module to throw its own error.