### PR TITLE
Don't parse more digits that we know we'll need

### DIFF
--- a/test/floats.jl
+++ b/test/floats.jl
@@ -317,6 +317,7 @@ x, code, vpos, vlen, tlen = Parsers.xparse(Float64, case.str)
 
 # https://github.com/quinnj/JSON3.jl/issues/57
 @test_throws Parsers.Error Parsers.parse(Float64,join(rand(1:9, 2000), ""))
-@test Parsers.parse(BigFloat, "3.14") == BigFloat(3.14)
+@test Parsers.parse(BigFloat, "3.14") == BigFloat("3.14")
+@test Parsers.parse(BigFloat, "3.14 ") == BigFloat("3.14")
 
 end # @testset

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -315,4 +315,8 @@ x, code, vpos, vlen, tlen = Parsers.xparse(Float64, case.str)
 @test code == case.code
 @test vlen == tlen == 39
 
+# https://github.com/quinnj/JSON3.jl/issues/57
+@test_throws Parsers.Error Parsers.parse(Float64,join(rand(1:9, 2000), ""))
+@test Parsers.parse(BigFloat, "3.14") == BigFloat(3.14)
+
 end # @testset


### PR DESCRIPTION
Originally posted as a security issue here:
https://github.com/quinnj/JSON3.jl/issues/57. The problem was that no
matter how many digits were in the input string, we tried to consume
them all, even though there are limits to the number of digits that can
realistically be useful for a given float precision. The change here
checks for those limits and if we go beyond the allowed # of digits,
we'll mark the input as invalid and bail; thus avoiding the "hang"
encountered in the original issue.