### PR TITLE
Make sure Parsers.parse consume full input for non-IO arguments

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -129,13 +129,15 @@ const XOPTIONS = Options(missing, UInt8(' '), UInt8('\t'), UInt8('"'), UInt8('"'
 "Attempt to parse a value of type `T` from string `buf`. Throws `Parsers.Error` on parser failures and invalid values."
 function parse(::Type{T}, buf::Union{AbstractVector{UInt8}, AbstractString, IO}, options=OPTIONS; pos::Integer=1, len::Integer=buf isa IO ? 0 : sizeof(buf)) where {T}
     x, code, vpos, vlen, tlen = xparse(T, buf isa AbstractString ? codeunits(buf) : buf, pos, len, options)
-    return ok(code) ? x : throw(Error(buf, T, code, pos, tlen))
+    fin = buf isa IO || (vlen == (len - pos + 1))
+    return ok(code) && fin ? x : throw(Error(buf, T, code, pos, tlen))
 end
 
 "Attempt to parse a value of type `T` from `buf`. Returns `nothing` on parser failures and invalid values."
 function tryparse(::Type{T}, buf::Union{AbstractVector{UInt8}, AbstractString, IO}, options=OPTIONS; pos::Integer=1, len::Integer=buf isa IO ? 0 : sizeof(buf)) where {T}
     x, code, vpos, vlen, tlen = xparse(T, buf isa AbstractString ? codeunits(buf) : buf, pos, len, options)
-    return ok(code) ? x : nothing
+    fin = buf isa IO || (vlen == (len - pos + 1))
+    return ok(code) && fin ? x : nothing
 end
 
 default(::Type{T}) where {T <: Integer} = zero(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -446,6 +446,12 @@ x, code, vpos, vlen, tlen = Parsers.xparse(String, "\"\"", 1, 2)
 @test Parsers.parse(DateTime, "7/22/1998 4:37:01.500 PM", Parsers.Options(dateformat="m/d/yyyy I:M:S.s p")) == DateTime(1998, 7, 22, 16, 37, 1, 500)
 end
 
+# #55
+# Parsers.parse must consume entire string
+@test_throws Parsers.Error Parsers.parse(Int, "10a")
+# but with IO will just consume until non digit
+@test Parsers.parse(Int, IOBuffer("10a")) == 10
+
 end # @testset "misc"
 
 include("floats.jl")


### PR DESCRIPTION
There were cases like `"10a"` where `Parsers.parse` would consume the
`10` and then stop parsing because it encountered `a` and return
successful. We now have a check for non-IO arguments that we consumed
the full input. For IO, we keep the same behavior where digits will be
consumed and we'll stop once we encountered non-digit. Fixes #55.