### PR TITLE
Fix edge cases of floats on various type promotion boundaries

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -313,13 +313,13 @@ pow10(::Type{Float32}, e) = (@inbounds v = F32_SHORT_POWERS[e+1]; return v)
 pow10(::Type{Float64}, e) = (@inbounds v = F64_SHORT_POWERS[e+1]; return v)
 pow10(::Type{BigFloat}, e) = (@inbounds v = F64_SHORT_POWERS[e+1]; return v)
 
-const BIGEXP10 = [1 / exp10(BigInt(e)) for e = 309:324]
+const BIGEXP10 = [1 / exp10(BigInt(e)) for e = 309:326]
 const BIGFLOAT = [BigFloat()]
 
 @inline function scale(::Type{T}, v::V, exp, neg) where {T, V <: Union{UInt128, BigInt}}
     if exp > 308
         return T(neg ? -Inf : Inf)
-    elseif exp < -325
+    elseif exp < -327
         return zero(T)
     elseif exp < -308
         y = BIGEXP10[-exp - 308]
@@ -362,7 +362,7 @@ end
     v == 0 && return zero(T)
     if exp > 308
         return T(neg ? -Inf : Inf)
-    elseif exp < -325
+    elseif exp < -327
         return zero(T)
     end
     mant, pow = pow10spl(exp + 325)

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -340,4 +340,10 @@ bytes = codeunits("a,b,c\n.,1,3")
 x, code, vpos, vlen, tlen = Parsers.xparse(Float64, bytes, 7, 11)
 @test code == (INVALID | DELIMITED)
 
+# https://github.com/JuliaData/CSV.jl/issues/710
+# problematic really small floats on various threshold boundaries
+@test Parsers.parse(Float64, "9.88e-324") === 1.0e-323
+@test Parsers.parse(Float64, "4.94e-324") === 5.0e-324
+@test Parsers.parse(Float64, "8.40e-323") === 8.4e-323
+
 end # @testset


### PR DESCRIPTION
Fixes https://github.com/JuliaData/CSV.jl/issues/710.

The issue here is that we weren't accounting for `exp` adjustments when
considering various boundaries. That is, the negative `exp` boundary was
325, but because you could have a number like `4.94e-324`, the `exp`
actually gets adjusted to 326 (because of the 2 digits after the decimal
place), and we can still accurately calculate this number, but our
boundary was set at 325. This PR adjusts the boundaries to account for
these adjustments and allows sucessfully parsing some of the smallest
allowed floats.