### PR TITLE
Fix the non-negative case of previous corner case

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -185,7 +185,7 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
         pos += 1
         incr!(source)
         if eof(source, pos, len)
-            x = ifelse(neg, -T(digits), digits)
+            x = ifelse(neg, -T(digits), T(digits))
             code |= ((startpos + 1) == pos ? INVALID : OK) | EOF
             @goto done
         end
@@ -195,7 +195,7 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
                 code |= INVALID
                 @goto done
             else
-                x = ifelse(neg, -T(digits), digits)
+                x = ifelse(neg, -T(digits), T(digits))
                 code |= OK
                 @goto done
             end

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -345,5 +345,6 @@ x, code, vpos, vlen, tlen = Parsers.xparse(Float64, bytes, 7, 11)
 @test Parsers.parse(Float64, "9.88e-324") === 1.0e-323
 @test Parsers.parse(Float64, "4.94e-324") === 5.0e-324
 @test Parsers.parse(Float64, "8.40e-323") === 8.4e-323
+@test Parsers.parse(Float64, "3091.") === 3091.0
 
 end # @testset


### PR DESCRIPTION
Follow up to https://github.com/JuliaData/Parsers.jl/pull/61, which
didn't quite fix the same issue for non-negative cases.