### PR TITLE
Support Char/Symbol parsing from string

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -757,4 +757,22 @@ end
     return x, code, vpos, vlen, tlen
 end
 
+@inline function xparse(::Type{Char}, source, pos, len, options)
+    _, code, vpos, vlen, tlen = xparse(String, source, pos, len, options)
+    x = '\0'
+    if !Parsers.sentinel(code) && code > 0
+        x = unsafe_string(pointer(source, vpos), vlen)[1]
+    end
+    return x, code, vpos, vlen, tlen
+end
+
+@inline function xparse(::Type{Symbol}, source, pos, len, options)
+    _, code, vpos, vlen, tlen = xparse(String, source, pos, len, options)
+    x = Symbol()
+    if !Parsers.sentinel(code) && code > 0
+        x = ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), pointer(source, vpos), vlen)
+    end
+    return x, code, vpos, vlen, tlen
+end
+
 end # module

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -281,6 +281,13 @@
             end
             b = peekbyte(source, pos)
         end
+    else
+        # no delimiter, so read until EOF
+        while !eof(source, pos, len)
+            pos += 1
+            vpos += 1
+            incr!(source)
+        end
     end
 
 @label donedone

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -452,6 +452,12 @@ end
 # but with IO will just consume until non digit
 @test Parsers.parse(Int, IOBuffer("10a")) == 10
 
+# #65
+@test Parsers.parse(Char, "a") === 'a'
+@test Parsers.parse(Char, "漢") === '漢'
+@test Parsers.parse(Symbol, "a") === :a
+@test Parsers.parse(Symbol, "漢") === :漢
+
 end # @testset "misc"
 
 include("floats.jl")


### PR DESCRIPTION
Fixes #65. The Parsers.parse fallback relied on zero(T) being defined
for the type T we were trying to parse, so we add two separate methods
for Char/Symbol that do what we want instead. This allows CSV.jl to
handle Char/Symbol columns as custom types.