### PR TITLE
add a few precompile statements

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -775,4 +775,6 @@ end
     return x, code, vpos, vlen, tlen
 end
 
+include("precompile.jl")
+
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,7 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    precompile(Tuple{typeof(Parsers.parse), Type{Int64}, String})
+    precompile(Tuple{typeof(Parsers.parse), Type{Float64}, String})
+    precompile(Tuple{typeof(Parsers.parse), Type{Date}, String})
+end
+_precompile_()


### PR DESCRIPTION
This takes

```jl
@time begin
    using Parsers
    Parsers.parse(Int, "101")
    Parsers.parse(Float64, "101.101")
    Parsers.parse(Date, "2018-01-01")
end
``` 

from about 1.4 seconds to 0.5 seconds on julia master.