### PR TITLE
Fix signed integer overflow case for float parsing

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -167,7 +167,7 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
             println("float 2) $(Char(b + UInt8('0')))")
         end
         b > 0x09 && break
-        if overflows(IntType) && digits > overflowval(IntType)
+        if overflows(inttype(IntType)) && digits > overflowval(inttype(IntType))
             fastseek!(source, startpos)
             return _typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
         elseif ndigits > maxdigits(T)
@@ -185,6 +185,7 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
         pos += 1
         incr!(source)
         if eof(source, pos, len)
+            digits = inttype(IntType)(digits)
             x = ifelse(neg, -T(digits), T(digits))
             code |= ((startpos + 1) == pos ? INVALID : OK) | EOF
             @goto done
@@ -195,6 +196,7 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
                 code |= INVALID
                 @goto done
             else
+                digits = inttype(IntType)(digits)
                 x = ifelse(neg, -T(digits), T(digits))
                 code |= OK
                 @goto done
@@ -222,7 +224,7 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
                 println("float 5) $b")
             end
             b > 0x09 && break
-            if overflows(IntType) && digits > overflowval(IntType)
+            if overflows(inttype(IntType)) && digits > overflowval(inttype(IntType))
                 fastseek!(source, startpos)
                 return _typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
             end

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -157,7 +157,6 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
         incr!(source)
         ndigits += 1
         if eof(source, pos, len)
-            digits = inttype(IntType)(digits)
             x = ifelse(neg, -T(digits), T(digits))
             code |= OK | EOF
             @goto done
@@ -167,7 +166,7 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
             println("float 2) $(Char(b + UInt8('0')))")
         end
         b > 0x09 && break
-        if overflows(inttype(IntType)) && digits > overflowval(inttype(IntType))
+        if overflows(IntType) && digits > overflowval(IntType)
             fastseek!(source, startpos)
             return _typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
         elseif ndigits > maxdigits(T)
@@ -185,7 +184,6 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
         pos += 1
         incr!(source)
         if eof(source, pos, len)
-            digits = inttype(IntType)(digits)
             x = ifelse(neg, -T(digits), T(digits))
             code |= ((startpos + 1) == pos ? INVALID : OK) | EOF
             @goto done
@@ -196,7 +194,6 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
                 code |= INVALID
                 @goto done
             else
-                digits = inttype(IntType)(digits)
                 x = ifelse(neg, -T(digits), T(digits))
                 code |= OK
                 @goto done
@@ -224,7 +221,7 @@ maxdigits(::Type{BigFloat}) = typemax(Int64)
                 println("float 5) $b")
             end
             b > 0x09 && break
-            if overflows(inttype(IntType)) && digits > overflowval(inttype(IntType))
+            if overflows(IntType) && digits > overflowval(IntType)
                 fastseek!(source, startpos)
                 return _typeparser(T, source, startpos, len, origb, code, options, wider(IntType))
             end

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -347,4 +347,7 @@ x, code, vpos, vlen, tlen = Parsers.xparse(Float64, bytes, 7, 11)
 @test Parsers.parse(Float64, "8.40e-323") === 8.4e-323
 @test Parsers.parse(Float64, "3091.") === 3091.0
 
+# https://github.com/JuliaData/CSV.jl/issues/769
+@test Parsers.parse(Float64, "9223372036854775808") === 9.223372036854776e18
+
 end # @testset


### PR DESCRIPTION
Fixes https://github.com/JuliaData/CSV.jl/issues/769. The issue here is
our `digits` variable for tracking all digits we've parsed in decimal
form is an unsigned integer, but might be converted to a signed integer
in cases where there's no decimal point or a decimal point with no
trailing digits. It turns out, we don't even need to convert to signed
integer, so the fix is pretty simple of just removing that conversion.