### PR TITLE
Make a copy of input sentinels if provided

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -76,7 +76,7 @@ function Options(
                 throw(ArgumentError("sentinel value isn't allowed to start with a delimiter string"))
             end
         end
-        refs = sentinel
+        refs = copy(sentinel)
     else
         refs = [""]
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -467,6 +467,11 @@ end
 # 67
 @test Parsers.parse(CustomType, "hey there", Parsers.XOPTIONS) == CustomType("hey there")
 
+# https://github.com/JuliaData/CSV.jl/issues/780
+missings = ["na"]
+opts = Parsers.Options(sentinel=missings, trues=["true"])
+@test missings == ["na"]
+
 end # @testset "misc"
 
 include("floats.jl")


### PR DESCRIPTION
Fixes https://github.com/JuliaData/CSV.jl/issues/780. The issue here is
Parsers.Options was assuming ownership of and modifying the input
`sentinel` if it was a `Vector{String}`. The fix is to make a copy
instead and then we can modify and use it to store references to other
strings as needed.