### PR TITLE
Improve float parsing performance for many digits (bigfloat size)

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -743,7 +743,8 @@ include("ryu.jl")
 function __init__()
     # floats.jl globals
     Threads.resize_nthreads!(BIGFLOAT)
-    Threads.resize_nthreads!(BIGFLOAT2)
+    Threads.resize_nthreads!(BIGINT)
+    Threads.resize_nthreads!(UINT128)
     return
 end
 

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -744,7 +744,6 @@ function __init__()
     # floats.jl globals
     Threads.resize_nthreads!(BIGFLOAT)
     Threads.resize_nthreads!(BIGINT)
-    Threads.resize_nthreads!(UINT128)
     return
 end
 

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -743,6 +743,7 @@ include("ryu.jl")
 function __init__()
     # floats.jl globals
     Threads.resize_nthreads!(BIGFLOAT)
+    Threads.resize_nthreads!(BIGFLOAT2)
     return
 end
 

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -468,7 +468,11 @@ end
 
 const BIGEXP10 = [1 / exp10(BigInt(e)) for e = 309:326]
 const BIGFLOAT = [BigFloat()]
+if version > v"1.5"
 const BIGFLOATEXP10 = [exp10(BigFloat(i; precision=64)) for i = 1:308]
+else
+const BIGFLOATEXP10 = [exp10(BigFloat(i)) for i = 1:308]
+end
 
 @inline function _scale(::Type{T}, v::V, exp, neg) where {T, V <: BigInt}
     @inbounds x = BIGFLOAT[Threads.threadid()]

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -3,14 +3,12 @@ using Base.MPFR, Base.GMP, Base.GMP.MPZ
 _widen(x::UInt64) = UInt128(x)
 
 const BIGINT = [BigInt(; nbits=256)]
-const UINT128 = [UInt128(0)]
 
 function _widen(v::UInt128)
     @inbounds x = BIGINT[Threads.threadid()]
-    @inbounds UINT128[Threads.threadid()] = v
     ccall((:__gmpz_import, :libgmp), Int32,
-        (Ref{BigInt}, Csize_t, Cint, Csize_t, Cint, Csize_t, Ptr{Cvoid}),
-        x, 1, 1, 16, 0, 0, pointer(UINT128))
+        (Ref{BigInt}, Csize_t, Cint, Csize_t, Cint, Csize_t, Ref{UInt128}),
+        x, 1, 1, 16, 0, 0, v)
     return x
 end
 

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -468,7 +468,7 @@ end
 
 const BIGEXP10 = [1 / exp10(BigInt(e)) for e = 309:326]
 const BIGFLOAT = [BigFloat()]
-if version > v"1.5"
+if VERSION > v"1.5"
 const BIGFLOATEXP10 = [exp10(BigFloat(i; precision=64)) for i = 1:308]
 else
 const BIGFLOATEXP10 = [exp10(BigFloat(i)) for i = 1:308]

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -2,7 +2,11 @@ using Base.MPFR, Base.GMP, Base.GMP.MPZ
 
 _widen(x::UInt64) = UInt128(x)
 
+if VERSION > v"1.5"
 const BIGINT = [BigInt(; nbits=256)]
+else
+const BIGINT = [BigInt()]
+end
 
 function _widen(v::UInt128)
     @inbounds x = BIGINT[Threads.threadid()]

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -1,7 +1,18 @@
-wider(::Type{UInt64}) = UInt128
-wider(::Type{Int64}) = Int128
-wider(::Type{UInt128}) = BigInt
-wider(::Type{Int128}) = BigInt
+using Base.MPFR, Base.GMP, Base.GMP.MPZ
+
+_widen(x::UInt64) = UInt128(x)
+
+const BIGINT = [BigInt(; nbits=256)]
+const UINT128 = [UInt128(0)]
+
+function _widen(v::UInt128)
+    @inbounds x = BIGINT[Threads.threadid()]
+    @inbounds UINT128[Threads.threadid()] = v
+    ccall((:__gmpz_import, :libgmp), Int32,
+        (Ref{BigInt}, Csize_t, Cint, Csize_t, Cint, Csize_t, Ptr{Cvoid}),
+        x, 1, 1, 16, 0, 0, pointer(UINT128))
+    return x
+end
 
 # Base.exponent_max(T) + Base.significand_bits(T) + 3 # "-0."
 maxdigits(::Type{Float64}) = 1079
@@ -21,14 +32,10 @@ function _muladd(ten, digits::BigInt, b)
     return digits
 end
 
-# include a non-inlined version in case of widening (otherwise, all widened cases would fully inline)
-@noinline _typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, ::Type{IntType}) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType} =
-    typeparser(T, source, pos, len, b, code, options, IntType)
-
-@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, ::Type{IntType}=UInt64) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
+    # keep track of starting pos in case of invalid, we can rewind to start of parsing
     startpos = pos
     x = zero(T)
-    digits = zero(IntType)
     if debug
         println("float parsing")
     end
@@ -38,12 +45,13 @@ end
         incr!(source)
     end
     if eof(source, pos, len)
+        # invalid because input is empty or contained only '-' or '+'
         code |= INVALID | EOF
         @goto done
     end
     b = peekbyte(source, pos)
     if b != options.decimal && (b - UInt8('0')) > 0x09
-        # character isn't a digit, check for special values, otherwise INVALID
+        # character isn't a digit or decimal point, check for special values, otherwise INVALID
         if b == UInt8('n') || b == UInt8('N')
             pos += 1
             incr!(source)
@@ -152,18 +160,21 @@ end
         @goto done
     end
 
-    x, code, pos = parsedigits(T, source, pos, len, b, code, options, digits, neg, startpos)
+    # start parsing digits or decimal point; we start digits as UInt64(0) and can _widen type if needed
+    x, code, pos = parsedigits(T, source, pos, len, b, code, options, UInt64(0), neg, startpos)
 
 @label done
     return x, code, pos
 end
 
+# if we need to _widen the type due to `digits` overflow, we want a non-inlined version to base case compilation doesn't get out of control
 @noinline _parsedigits(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits::IntType, neg::Bool, startpos) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType} =
     parsedigits(T, source, pos, len, b, code, options, digits, neg, startpos)
 
 @inline function parsedigits(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits::IntType, neg::Bool, startpos) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType}
     x = zero(T)
     ndigits = 0
+    # we already previously check if `b` was decimal or a digit, so don't need to check explicitly again
     if b != options.decimal
         b -= UInt8('0')
         if debug
@@ -175,6 +186,7 @@ end
             incr!(source)
             ndigits += 1
             if eof(source, pos, len)
+                # input is integer, like "1"
                 x = ifelse(neg, -T(digits), T(digits))
                 code |= OK | EOF
                 @goto done
@@ -183,15 +195,18 @@ end
             if debug
                 println("float 2) $(Char(b + UInt8('0')))")
             end
+            # if `b` isn't a digit, time to break out of digit parsing while loop
             b > 0x09 && break
             if overflows(IntType) && digits > overflowval(IntType)
-                return _parsedigits(T, source, pos, len, b + UInt8('0'), code, options, wider(IntType)(digits), neg, startpos)
+                return _parsedigits(T, source, pos, len, b + UInt8('0'), code, options, _widen(digits), neg, startpos)
             elseif ndigits > maxdigits(T)
+                # if input is way too big, just bail
                 fastseek!(source, startpos)
                 code |= INVALID
                 @goto done
             end
         end
+        # b wasn't a digit, so add back '0' to recover original Char value
         b += UInt8('0')
         if debug
             println("float 3) $(Char(b))")
@@ -201,12 +216,16 @@ end
         pos += 1
         incr!(source)
         if eof(source, pos, len)
+            # if input is "." then invalid, otherwise ok, like "1."
             x = ifelse(neg, -T(digits), T(digits))
             code |= ((startpos + 1) == pos ? INVALID : OK) | EOF
             @goto done
         end
         b = peekbyte(source, pos)
         if b - UInt8('0') > 0x09 && !(b == UInt8('e') || b == UInt8('E') || b == UInt8('f') || b == UInt8('F'))
+            # if the next byte after decimal point isn't a digit or exponent char ('e', 'E', 'f', 'F')
+            # and we haven't parsed any digits, like ".a", then invalid
+            # otherwise ok, like "1.a" (only "1." is parsed)
             if ndigits == 0
                 code |= INVALID
                 @goto done
@@ -218,12 +237,19 @@ end
         end
     end
 
-    x, code, pos = parsefrac(T, source, pos, len, b, code, options, digits, neg, startpos, Int64(0))
+    # we've parsed any digits preceding decimal point and consumed decimal point if any
+    # now we parse any digits following decimal point (if any); start `frac` at UInt64(0)
+    # `digits` still receives any fractional digits, `frac` just keeps track of how many digits
+    # were parsed to combine with any "e123" exponent numbers to determine final exponent value
+    x, code, pos = parsefrac(T, source, pos, len, b, code, options, digits, neg, startpos, UInt64(0))
 
 @label done
     return x, code, pos
 end
 
+# same as above; if digits overflows, we want a non-inlined version to call with a wider type
+# note that we never expect `frac` to overflow, since it's just keep track of the # of digits
+# we parse post-decimal point
 @noinline _parsefrac(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits::IntType, neg::Bool, startpos, frac) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType} =
     parsefrac(T, source, pos, len, b, code, options, digits, neg, startpos, frac)
 
@@ -232,15 +258,18 @@ end
     if debug
         println("float 4) $(Char(b + UInt8('0')))")
     end
+    # check if `b` is a digit
     if b - UInt8('0') < 0x0a
         b -= UInt8('0')
+        # if so, parse fractional digits
         while true
             digits = _muladd(ten(IntType), digits, b)
             pos += 1
             incr!(source)
-            frac += Int64(1)
+            frac += UInt64(1)
             if eof(source, pos, len)
-                x = scale(T, digits, -frac, neg)
+                # input is simple non-scientific-notation floating number, like "1.1"
+                x = scale(T, digits, -signed(frac), neg)
                 code |= OK | EOF
                 @goto done
             end
@@ -250,7 +279,7 @@ end
             end
             b > 0x09 && break
             if overflows(IntType) && digits > overflowval(IntType)
-                return _parsefrac(T, source, pos, len, b + UInt8('0'), code, options, wider(IntType)(digits), neg, startpos, frac)
+                return _parsefrac(T, source, pos, len, b + UInt8('0'), code, options, _widen(digits), neg, startpos, frac)
             end
         end
         b += UInt('0')
@@ -262,8 +291,8 @@ end
     if b == UInt8('e') || b == UInt8('E') || b == UInt8('f') || b == UInt8('F')
         pos += 1
         incr!(source)
-        # error to have a "dangling" 'e'
         if eof(source, pos, len)
+            # it's an error to have a "dangling" 'e', so input was something like "1.1e"
             code |= INVALID | EOF
             @goto done
         end
@@ -271,6 +300,7 @@ end
         if debug
             println("float 7) $(Char(b))")
         end
+        # check for plus or minus sign for exponent number
         negexp = b == UInt8('-')
         if negexp || b == UInt8('+')
             pos += 1
@@ -286,9 +316,12 @@ end
             @goto done
         end
 
-        return parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, Int64(0), negexp)
+        # at this point, we've parsed X and Y in "X.YeZ", but not Z in a scientific notation exponent number
+        # we start our exponent number at UInt64(0)
+        return parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, UInt64(0), negexp)
     else
-        x = scale(T, digits, -frac, neg)
+        # if no scientific notation, we're done, so scale digits + frac and return
+        x = scale(T, digits, -signed(frac), neg)
         code |= OK
     end
 
@@ -296,17 +329,21 @@ end
     return x, code, pos
 end
 
+# same no-inline story, but this time for exponent number; probably even more rare to overflow the exponent number
+# compared to pre/post decimal digits, but we account for it all the same (a lot of float parsers don't account for this)
 @noinline _parseexp(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits, neg::Bool, startpos, frac, exp::ExpType, negexp) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, ExpType} =
     parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, exp, negexp)
 
 @inline function parseexp(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits, neg::Bool, startpos, frac, exp::ExpType, negexp) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, ExpType}
     x = zero(T)
+    # note that `b` has already had `b - UInt8('0')` applied to it for parseexp
     while true
         exp = ExpType(10) * exp + b
         pos += 1
         incr!(source)
         if eof(source, pos, len)
-            x = scale(T, digits, ifelse(negexp, -exp, exp) - frac, neg)
+            # we finished parsing input like "1.1e1"
+            x = scale(T, digits, ifelse(negexp, -signed(exp), signed(exp)) - signed(frac), neg)
             code |= OK | EOF
             @goto done
         end
@@ -314,20 +351,19 @@ end
         if debug
             println("float 9) $b")
         end
+        # if we encounter a non-digit, that must mean we're done
         if b > 0x09
-            x = scale(T, digits, ifelse(negexp, -exp, exp) - frac, neg)
+            x = scale(T, digits, ifelse(negexp, -signed(exp), signed(exp)) - signed(frac), neg)
             code |= OK
             @goto done
         end
         if overflows(ExpType) && exp > overflowval(ExpType)
-            return _parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, wider(ExpType)(exp), negexp)
+            return _parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, _widen(exp), negexp)
         end
     end
 @label done
     return x, code, pos
 end
-
-using Base.MPFR, Base.GMP, Base.GMP.MPZ
 
 maxsig(::Type{Float16}) = 2048
 maxsig(::Type{Float32}) = 16777216
@@ -339,78 +375,16 @@ ceillog5(::Type{Float32}) = 11
 ceillog5(::Type{Float64}) = 23
 ceillog5(::Type{BigFloat}) = 23
 
-const F16_SHORT_POWERS = [exp10(Float16(x)) for x = 0:2ceillog5(Float16)-1]
-const F32_SHORT_POWERS = [exp10(Float32(x)) for x = 0:2ceillog5(Float32)-1]
-const F64_SHORT_POWERS = [exp10(Float64(x)) for x = 0:2ceillog5(Float64)-1]
+const F16_SHORT_POWERS = [exp10(Float16(x)) for x = 0:ceillog5(Float16)-1]
+const F32_SHORT_POWERS = [exp10(Float32(x)) for x = 0:ceillog5(Float32)-1]
+const F64_SHORT_POWERS = [exp10(Float64(x)) for x = 0:ceillog5(Float64)-1]
 
 pow10(::Type{Float16}, e) = (@inbounds v = F16_SHORT_POWERS[e+1]; return v)
 pow10(::Type{Float32}, e) = (@inbounds v = F32_SHORT_POWERS[e+1]; return v)
 pow10(::Type{Float64}, e) = (@inbounds v = F64_SHORT_POWERS[e+1]; return v)
 pow10(::Type{BigFloat}, e) = (@inbounds v = F64_SHORT_POWERS[e+1]; return v)
 
-const BIGEXP10 = [1 / exp10(BigInt(e)) for e = 309:326]
-const BIGFLOAT = [BigFloat()]
-const BIGFLOAT2 = [BigFloat()]
-
-@inline function scale(::Type{T}, v::V, exp, neg) where {T, V <: Union{UInt128, BigInt}}
-    if exp > 308
-        return T(neg ? -Inf : Inf)
-    elseif exp < -326
-        return zero(T)
-    elseif exp < -308
-        y = BIGEXP10[-exp - 308]
-        @inbounds x = BIGFLOAT[Threads.threadid()]
-        if v > 9007199254740992
-            ccall((:mpfr_set_z, :libmpfr), Int32,
-                (Ref{BigFloat}, Ref{BigInt}, Int32),
-                x, BigInt(v), MPFR.ROUNDING_MODE[])
-        else
-            ccall((:mpfr_set_d, :libmpfr), Int32,
-                (Ref{BigFloat}, Float64, Int32),
-                x, Float64(v), MPFR.ROUNDING_MODE[])
-        end
-        ccall((:mpfr_mul, :libmpfr), Int32,
-            (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
-            x, x, y, MPFR.ROUNDING_MODE[])
-    elseif exp < 0
-        if v isa BigInt
-            @inbounds x = BIGFLOAT[Threads.threadid()]
-            @inbounds y = BIGFLOAT2[Threads.threadid()]
-            ccall((:mpfr_set_z, :libmpfr), Int32,
-                (Ref{BigFloat}, Ref{BigInt}, Int32),
-                x, v, MPFR.ROUNDING_MODE[])
-            ccall((:mpfr_set_d, :libmpfr), Int32,
-                (Ref{BigFloat}, Float64, Int32),
-                y, -exp, MPFR.ROUNDING_MODE[])
-            ccall((:mpfr_exp10, :libmpfr), Int32,
-                (Ref{BigFloat}, Ref{BigFloat}, Int32),
-                y, y, MPFR.ROUNDING_MODE[])
-            ccall((:mpfr_div, :libmpfr), Int32,
-                (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
-                x, x, y, MPFR.ROUNDING_MODE[])
-        else
-            x = v / exp10(V(-exp))
-        end
-    elseif exp == 23
-        # special-case due to https://github.com/JuliaLang/julia/issues/38509
-        x = v * V(1e23)
-    else
-        if v isa BigInt
-            @inbounds x = BIGFLOAT[Threads.threadid()]
-            ccall((:mpfr_set_z, :libmpfr), Int32,
-                (Ref{BigFloat}, Ref{BigInt}, Int32),
-                x, v, MPFR.ROUNDING_MODE[])
-            ccall((:mpfr_mul_d, :libmpfr), Int32,
-                (Ref{BigFloat}, Ref{BigFloat}, Float64, Int32),
-                x, x, exp10(-exp), MPFR.ROUNDING_MODE[])
-        else
-            x = v * exp10(V(exp))
-        end
-    end
-    return T(neg ? -x : x)
-end
-
-@inline function scale(::Type{T}, v::UInt64, exp, neg) where {T}
+@inline function scale(::Type{T}, v, exp, neg) where {T}
     ms = maxsig(T)
     cl = ceillog5(T)
     if v < ms
@@ -429,6 +403,10 @@ end
     elseif exp < -326
         return zero(T)
     end
+    return _scale(T, v, exp, neg)
+end
+
+@inline function _scale(::Type{T}, v::UInt64, exp, neg) where {T}
     mant, pow = pow10spl(exp + 326)
     lz = leading_zeros(v)
     newv = v << lz
@@ -444,7 +422,7 @@ end
         end
         if (product_middle + 1 == 0) && (product_high & 0x1FF == 0x1FF) &&
             (product_low + v < product_low)
-            return scale(T, UInt128(v), exp, neg)
+            return _scale(T, UInt128(v), exp, neg)
         end
         upper = product_high
         lower = product_middle
@@ -453,7 +431,7 @@ end
     mantissa = upper >> (upperbit + 9)
     lz += xor(1, upperbit)
     if (lower == 0) && upper & 0x1FF == 0 && mantissa & 3 == 1
-        return scale(T, UInt128(v), exp, neg)
+        return _scale(T, UInt128(v), exp, neg)
     end
     mantissa += mantissa & 1
     mantissa >>= 1
@@ -464,11 +442,57 @@ end
     mantissa &= ~(UInt64(1) << 52)
     real_exponent = pow - lz
     if real_exponent < 1 || real_exponent > 2046
-        return scale(T, UInt128(v), exp, neg)
+        return _scale(T, UInt128(v), exp, neg)
     end
     mantissa |= real_exponent << 52
     mantissa |= (UInt64(neg) << 63)
     return T(Core.bitcast(Float64, mantissa))
+end
+
+@inline function _scale(::Type{T}, v::V, exp, neg) where {T, V <: UInt128}
+    if exp == 23
+        # special-case due to https://github.com/JuliaLang/julia/issues/38509
+        x = v * V(1e23)
+    elseif exp > 0
+        x = v * exp10(exp)
+    elseif exp < -308
+        y = _widen(v)
+        return _scale(T, y, exp, neg)
+    else
+        x = v / exp10(-exp)
+    end
+    return T(neg ? -x : x)
+end
+
+const BIGEXP10 = [1 / exp10(BigInt(e)) for e = 309:326]
+const BIGFLOAT = [BigFloat()]
+const BIGFLOATEXP10 = [exp10(BigFloat(i; precision=64)) for i = 1:308]
+
+@inline function _scale(::Type{T}, v::V, exp, neg) where {T, V <: BigInt}
+    @inbounds x = BIGFLOAT[Threads.threadid()]
+    ccall((:mpfr_set_z, :libmpfr), Int32,
+        (Ref{BigFloat}, Ref{BigInt}, Int32),
+        x, v, MPFR.ROUNDING_MODE[])
+    if exp < -308
+        # v * (1 / exp10(-exp))
+        y = BIGEXP10[-exp - 308]
+        ccall((:mpfr_mul, :libmpfr), Int32,
+            (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
+            x, x, y, MPFR.ROUNDING_MODE[])
+    elseif exp < 0
+        # v / exp10(-exp)
+        y = BIGFLOATEXP10[-exp]
+        ccall((:mpfr_div, :libmpfr), Int32,
+            (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
+            x, x, y, MPFR.ROUNDING_MODE[])
+    else
+        # v * exp10(V(exp))
+        y = BIGFLOATEXP10[exp]
+        ccall((:mpfr_mul, :libmpfr), Int32,
+            (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
+            x, x, y, MPFR.ROUNDING_MODE[])
+    end
+    return T(neg ? -x : x)
 end
 
 @inline function two_prod(a, b)


### PR DESCRIPTION
Improves timings reported in #70 by about 20x. Most of the performance
improvements come from avoiding BigInt/BigFloat allocations and re-using
thread-local objects for doing the necessary computations. The other
improvements come from avoiding duplicate work; previously, if we were
going to overflow our `digits` variable, which tracks the parsed
mantissa, we basically widened the type and started parsing over again.
In this PR, we restructure the code to allow immediately widening to a
wider typed value and then continuing the parsing algorithm. I think it
reads about as simply as before, so I'm content with that change.

I don't love how messy the `scale` code has gotten; it seems like we
have some duplicated logic between the `UInt128`/`BigInt` mantissa case
and the `UInt64` case, and it just doesn't seem to all follow a cohesive
strategy. Maybe I can get a beer for @simonbyrne at some point to help
clean that code up.