### PR TITLE
Fix undefined variable error when sentinel is provided but we reach EOF

### DIFF
--- a/src/strings.jl
+++ b/src/strings.jl
@@ -1,7 +1,7 @@
 # this is mostly copy-pasta from Parsers.jl main xparse function
 @inline function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: AbstractString, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
     startpos = vstartpos = vpos = pos
-    sentinelpos = 0
+    sentstart = sentinelpos = 0
     code = SUCCESS
     sentinel = options.sentinel
     quoted = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -472,6 +472,9 @@ missings = ["na"]
 opts = Parsers.Options(sentinel=missings, trues=["true"])
 @test missings == ["na"]
 
+# reported from Slack via CSV.jl
+@test Parsers.xparse(String, ""; sentinel=["NULL"]) == (33, 33, 1, 0, 0)
+
 end # @testset "misc"
 
 include("floats.jl")


### PR DESCRIPTION
Reported by Nils Gudat on slack. The problem here is that we defined our
`sentinelpos` variable at the top of the String parsing method, but
didn't defint `sentstart` until later, since by definition that variable
tracks where the sentinel starts, which might be after an opening quote
character. If we happened to start parsing and reach EOF, with a
provided sentinel string, we then checked at the end of the routine if
`sentstart == pos` and got an undefined variable error. The fix is
pretty easy, just define `sentstart` to be 0 at the top of the routine
along with `sentinelpos` to ensure it's always defined.