### PR TITLE
Fix timetype parsing on IO sources

### DIFF
--- a/src/dates.jl
+++ b/src/dates.jl
@@ -1,3 +1,11 @@
+@inline function xparse(::Type{T}, source::IO, pos, len, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: Dates.TimeType, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
+    _, _code, vpos, vlen, tlen = xparse(String, source, pos, len, options)
+    fastseek!(source, pos - 1)
+    bytes = Vector{UInt8}(undef, tlen)
+    tlen > 0 && readbytes!(source, bytes)
+    return xparse(T, bytes, 1, tlen, options)
+end
+
 @inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: Dates.TimeType, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
     df = options.dateformat === nothing ? Dates.default_format(T) : options.dateformat
     ret = mytryparsenext_internal(T, source, Int(pos), len, df)

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -68,3 +68,65 @@ x, code, vpos, vlen, tlen = Parsers.xparse(Date, "1,")
 @test_throws Parsers.Error Parsers.parse(DateTime, "2020-05-05T00:00:60")
 
 end
+
+@testset "Date.TimeTypes IO" begin
+
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer(""))
+    @test x === Date(0)
+    @test code == INVALID | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("2018-01-01"))
+    @test x === Date(2018, 1, 01)
+    @test code == OK | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(DateTime, IOBuffer("2018-01-01"))
+    @test x === DateTime(2018, 1, 01)
+    @test code == OK | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(Time, IOBuffer("01:02:03"))
+    @test x === Time(1, 2, 3)
+    @test code == OK | EOF
+    
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("\"\""))
+    @test x === Date(0)
+    @test code == QUOTED | INVALID | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("\"2018-01-01\""))
+    @test x === Date(2018, 1, 01)
+    @test code == QUOTED | OK | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(DateTime, IOBuffer("\"2018-01-01"))
+    @test code == OK | QUOTED | EOF | INVALID_QUOTED_FIELD
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("\"abcd\""))
+    @test x === Date(0)
+    @test code == QUOTED | INVALID | EOF
+    
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("NA"), sentinel=["NA"])
+    @test x === Date(0)
+    @test code === SENTINEL | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("\\N"), sentinel=["\\N"])
+    @test x === Date(0)
+    @test code === SENTINEL | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("NA2"), sentinel=["NA"])
+    @test x === Date(0)
+    @test code === SENTINEL | INVALID_DELIMITER | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("-"), sentinel=["-"])
+    @test x === Date(0)
+    @test code === SENTINEL | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("£"), sentinel=["£"])
+    @test x === Date(0)
+    @test code === SENTINEL | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("null"))
+    @test x === Date(0)
+    @test code === INVALID_DELIMITER | EOF
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer(","))
+    @test x === Date(0)
+    @test code === INVALID | DELIMITED
+    x, code, vpos, vlen, tlen = Parsers.xparse(Date, IOBuffer("1,"))
+    @test x === Date(1)
+    @test code === OK | DELIMITED
+    
+    @test Parsers.parse(DateTime, IOBuffer("1996/Feb/15"), Parsers.Options(dateformat="yy/uuu/dd")) === DateTime(1996, 2, 15)
+    @test Parsers.parse(DateTime, IOBuffer("1996, Jan, 15"), Parsers.Options(dateformat="yyyy, uuu, dd")) === DateTime(1996, 1, 15)
+    
+    @test_throws Parsers.Error Parsers.parse(Date, IOBuffer("2020-05-32"))
+    @test_throws Parsers.Error Parsers.parse(DateTime, IOBuffer("2020-05-32"))
+    @test_throws Parsers.Error Parsers.parse(Time, IOBuffer("25:00:00"))
+    @test_throws Parsers.Error Parsers.parse(DateTime, IOBuffer("2020-05-05T00:00:60"))
+
+end


### PR DESCRIPTION
Fixes #60. This is an annoying bug because the stdlib Dates parsing
machinery is all String-based, and the Parsers Dates parsing machinery
is all AbstractVector{UInt8}-based, which left IO out to dry. And
unfortunately, too annoying to write at the most performance low-level.
So we take the easier, but at least correct way out. We parse the date
string as a String, then pass the parsed string to the bytes-based
parsing machinery. So def a little slower than if you're parsing
directly from a string or byte vector, but not crazy bad.