### PR TITLE
Remove parameterization from Parsers.Options

### DIFF
--- a/src/bools.jl
+++ b/src/bools.jl
@@ -1,15 +1,15 @@
-@inline function typeparser(::Type{Bool}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
+@inline function typeparser(::Type{Bool}, source, pos, len, b, code, options::Options)
     x = false
-    if debug
-        println("start of Bool parsing")
-    end
+    # if debug
+    #     println("start of Bool parsing")
+    # end
     trues = options.trues
     falses = options.falses
     if trues === nothing
         if b == UInt8('t')
-            if debug
-                println("matched 't'")
-            end
+            # if debug
+            #     println("matched 't'")
+            # end
             pos += 1
             incr!(source)
             if eof(source, pos, len)
@@ -18,9 +18,9 @@
             end
             b = peekbyte(source, pos)
             if b == UInt8('r')
-                if debug
-                    println("matched 'r'")
-                end
+                # if debug
+                #     println("matched 'r'")
+                # end
                 pos += 1
                 incr!(source)
                 if eof(source, pos, len)
@@ -29,9 +29,9 @@
                 end
                 b = peekbyte(source, pos)
                 if b == UInt8('u')
-                    if debug
-                        println("matched 'u'")
-                    end
+                    # if debug
+                    #     println("matched 'u'")
+                    # end
                     pos += 1
                     incr!(source)
                     if eof(source, pos, len)
@@ -40,9 +40,9 @@
                     end
                     b = peekbyte(source, pos)
                     if b == UInt8('e')
-                        if debug
-                            println("matched 'e'")
-                        end
+                        # if debug
+                        #     println("matched 'e'")
+                        # end
                         pos += 1
                         incr!(source)
                         x = true

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -1,4 +1,4 @@
-@inline function xparse(::Type{T}, source::IO, pos, len, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: Dates.TimeType, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
+@inline function xparse(::Type{T}, source::IO, pos, len, options::Options) where {T <: Dates.TimeType}
     _, _code, vpos, vlen, tlen = xparse(String, source, pos, len, options)
     fastseek!(source, pos - 1)
     bytes = Vector{UInt8}(undef, tlen)
@@ -6,16 +6,16 @@
     return xparse(T, bytes, 1, tlen, options)
 end
 
-@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: Dates.TimeType, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options) where {T <: Dates.TimeType}
     df = options.dateformat === nothing ? Dates.default_format(T) : options.dateformat
     ret = mytryparsenext_internal(T, source, Int(pos), len, df)
-    if debug
-        if ret === nothing
-            println("failed to parse $T")
-        else
-            println("parsed: $ret")
-        end
-    end
+    # if debug
+    #     if ret === nothing
+    #         println("failed to parse $T")
+    #     else
+    #         println("parsed: $ret")
+    #     end
+    # end
     if ret === nothing
         x = default(T)
         code |= INVALID

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -34,18 +34,18 @@ function _muladd(ten, digits::BigInt, b)
     return digits
 end
 
-@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: Real, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options) where {T <: Real}
     x, code, pos = typeparser(Float64, source, pos, len, b, code, options)
     return T(x), code, pos
 end
 
-@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options) where {T <: SupportedFloats}
     # keep track of starting pos in case of invalid, we can rewind to start of parsing
     startpos = pos
     x = zero(T)
-    if debug
-        println("float parsing")
-    end
+    # if debug
+    #     println("float parsing")
+    # end
     neg = b == UInt8('-')
     if neg || b == UInt8('+')
         pos += 1
@@ -174,19 +174,19 @@ end
     return x, code, pos
 end
 
-# if we need to _widen the type due to `digits` overflow, we want a non-inlined version to base case compilation doesn't get out of control
-@noinline _parsedigits(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits::IntType, neg::Bool, startpos) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType} =
+# if we need to _widen the type due to `digits` overflow, we want a non-inlined version so base case compilation doesn't get out of control
+@noinline _parsedigits(::Type{T}, source, pos, len, b, code, options::Options, digits::IntType, neg::Bool, startpos) where {T <: SupportedFloats, IntType} =
     parsedigits(T, source, pos, len, b, code, options, digits, neg, startpos)
 
-@inline function parsedigits(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits::IntType, neg::Bool, startpos) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType}
+@inline function parsedigits(::Type{T}, source, pos, len, b, code, options::Options, digits::IntType, neg::Bool, startpos) where {T <: SupportedFloats, IntType}
     x = zero(T)
     ndigits = 0
     # we already previously check if `b` was decimal or a digit, so don't need to check explicitly again
     if b != options.decimal
         b -= UInt8('0')
-        if debug
-            println("float 1) $(Char(b + UInt8('0')))")
-        end
+        # if debug
+        #     println("float 1) $(Char(b + UInt8('0')))")
+        # end
         while true
             digits = _muladd(ten(IntType), digits, b)
             pos += 1
@@ -199,9 +199,9 @@ end
                 @goto done
             end
             b = peekbyte(source, pos) - UInt8('0')
-            if debug
-                println("float 2) $(Char(b + UInt8('0')))")
-            end
+            # if debug
+            #     println("float 2) $(Char(b + UInt8('0')))")
+            # end
             # if `b` isn't a digit, time to break out of digit parsing while loop
             b > 0x09 && break
             if overflows(IntType) && digits > overflowval(IntType)
@@ -215,9 +215,9 @@ end
         end
         # b wasn't a digit, so add back '0' to recover original Char value
         b += UInt8('0')
-        if debug
-            println("float 3) $(Char(b))")
-        end
+        # if debug
+        #     println("float 3) $(Char(b))")
+        # end
     end
     if b == options.decimal
         pos += 1
@@ -257,14 +257,14 @@ end
 # same as above; if digits overflows, we want a non-inlined version to call with a wider type
 # note that we never expect `frac` to overflow, since it's just keep track of the # of digits
 # we parse post-decimal point
-@noinline _parsefrac(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits::IntType, neg::Bool, startpos, frac) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType} =
+@noinline _parsefrac(::Type{T}, source, pos, len, b, code, options::Options, digits::IntType, neg::Bool, startpos, frac) where {T <: SupportedFloats, IntType} =
     parsefrac(T, source, pos, len, b, code, options, digits, neg, startpos, frac)
 
-@inline function parsefrac(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits::IntType, neg::Bool, startpos, frac) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, IntType}
+@inline function parsefrac(::Type{T}, source, pos, len, b, code, options::Options, digits::IntType, neg::Bool, startpos, frac) where {T <: SupportedFloats, IntType}
     x = zero(T)
-    if debug
-        println("float 4) $(Char(b + UInt8('0')))")
-    end
+    # if debug
+    #     println("float 4) $(Char(b + UInt8('0')))")
+    # end
     # check if `b` is a digit
     if b - UInt8('0') < 0x0a
         b -= UInt8('0')
@@ -281,9 +281,9 @@ end
                 @goto done
             end
             b = peekbyte(source, pos) - UInt8('0')
-            if debug
-                println("float 5) $b")
-            end
+            # if debug
+            #     println("float 5) $b")
+            # end
             b > 0x09 && break
             if overflows(IntType) && digits > overflowval(IntType)
                 return _parsefrac(T, source, pos, len, b + UInt8('0'), code, options, _widen(digits), neg, startpos, frac)
@@ -291,9 +291,9 @@ end
         end
         b += UInt('0')
     end
-    if debug
-        println("float 6) $(Char(b))")
-    end
+    # if debug
+    #     println("float 6) $(Char(b))")
+    # end
     # check for exponent notation
     if b == UInt8('e') || b == UInt8('E') || b == UInt8('f') || b == UInt8('F')
         pos += 1
@@ -304,9 +304,9 @@ end
             @goto done
         end
         b = peekbyte(source, pos)
-        if debug
-            println("float 7) $(Char(b))")
-        end
+        # if debug
+        #     println("float 7) $(Char(b))")
+        # end
         # check for plus or minus sign for exponent number
         negexp = b == UInt8('-')
         if negexp || b == UInt8('+')
@@ -314,9 +314,9 @@ end
             incr!(source)
         end
         b = peekbyte(source, pos) - UInt8('0')
-        if debug
-            println("float 8) $b")
-        end
+        # if debug
+        #     println("float 8) $b")
+        # end
         if b > 0x09
             # invalid to have a "dangling" 'e'
             code |= INVALID
@@ -338,10 +338,10 @@ end
 
 # same no-inline story, but this time for exponent number; probably even more rare to overflow the exponent number
 # compared to pre/post decimal digits, but we account for it all the same (a lot of float parsers don't account for this)
-@noinline _parseexp(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits, neg::Bool, startpos, frac, exp::ExpType, negexp) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, ExpType} =
+@noinline _parseexp(::Type{T}, source, pos, len, b, code, options::Options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp) where {T <: SupportedFloats, ExpType} =
     parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, exp, negexp)
 
-@inline function parseexp(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}, digits, neg::Bool, startpos, frac, exp::ExpType, negexp) where {T <: SupportedFloats, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF, ExpType}
+@inline function parseexp(::Type{T}, source, pos, len, b, code, options::Options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp) where {T <: SupportedFloats, ExpType}
     x = zero(T)
     # note that `b` has already had `b - UInt8('0')` applied to it for parseexp
     while true
@@ -355,9 +355,9 @@ end
             @goto done
         end
         b = peekbyte(source, pos) - UInt8('0')
-        if debug
-            println("float 9) $b")
-        end
+        # if debug
+        #     println("float 9) $b")
+        # end
         # if we encounter a non-digit, that must mean we're done
         if b > 0x09
             x = scale(T, digits, ifelse(negexp, -signed(exp), signed(exp)) - signed(frac), neg)
@@ -458,7 +458,7 @@ end
 
 @inline function _scale(::Type{T}, v::V, exp, neg) where {T, V <: UInt128}
     if exp == 23
-        # special-case due to https://github.com/JuliaLang/julia/issues/38509
+        # special-case concluded from https://github.com/JuliaLang/julia/issues/38509
         x = v * V(1e23)
     elseif exp > 0
         x = v * exp10(exp)

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -4,13 +4,13 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
 # if we eventually support non-base 10
 # overflowval(::Type{T}, base) where {T <: Integer} = div(typemax(T) - base + 1, base)
 
-@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options{ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}) where {T <: Integer, ignorerepeated, ignoreemptylines, Q, debug, S, D, DF}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, options::Options) where {T <: Integer}
     x = zero(T)
     neg = false
     # start actual int parsing
-    if debug
-        println("start of actual $T parsing")
-    end
+    # if debug
+    #     println("start of actual $T parsing")
+    # end
     neg = b == UInt8('-')
     if neg || b == UInt8('+')
         pos += 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,7 +76,7 @@ quotednotescaped(x::ReturnCode) = (x & (QUOTED | ESCAPED_STRING)) == QUOTED
 
 memcmp(a::Ptr{UInt8}, b::Ptr{UInt8}, len::Int) = ccall(:memcmp, Cint, (Ptr{UInt8}, Ptr{UInt8}, Csize_t), a, b, len) == 0
 
-@inline function checksentinel(source::AbstractVector{UInt8}, pos, len, sentinel, debug)
+@inline function checksentinel(source::AbstractVector{UInt8}, pos, len, sentinel)
     sentinelpos = 0
     startptr = pointer(source, pos)
     # sentinel is an iterable of Tuple{Ptr{UInt8}, Int}, sorted from longest sentinel string to shortest
@@ -84,9 +84,9 @@ memcmp(a::Ptr{UInt8}, b::Ptr{UInt8}, len::Int) = ccall(:memcmp, Cint, (Ptr{UInt8
         if pos + ptrlen - 1 <= len
             match = memcmp(startptr, ptr, ptrlen)
             if match
-                if debug
-                    println("matched sentinel value: \"$(escape_string(unsafe_string(ptr, ptrlen)))\"")
-                end
+                # if debug
+                #     println("matched sentinel value: \"$(escape_string(unsafe_string(ptr, ptrlen)))\"")
+                # end
                 sentinelpos = pos + ptrlen
                 break
             end
@@ -95,15 +95,15 @@ memcmp(a::Ptr{UInt8}, b::Ptr{UInt8}, len::Int) = ccall(:memcmp, Cint, (Ptr{UInt8
     return sentinelpos
 end
 
-@inline function checksentinel(source::IO, pos, len, sentinel, debug)
+@inline function checksentinel(source::IO, pos, len, sentinel)
     sentinelpos = 0
     origpos = position(source)
     for (ptr, ptrlen) in sentinel
         matched = match!(source, ptr, ptrlen)
         if matched
-            if debug
-                println("matched sentinel value: \"$(escape_string(unsafe_string(ptr, ptrlen)))\"")
-            end
+            # if debug
+            #     println("matched sentinel value: \"$(escape_string(unsafe_string(ptr, ptrlen)))\"")
+            # end
             sentinelpos = pos + ptrlen
             break
         end


### PR DESCRIPTION
Pinging a few people who may be interested in the change here: @bkamins @KristofferC @andreasnoack @nalimilan

As the PR title states, this removes any type parameters from the `Parsers.Options` struct. What this means in real terms, is that there were a few checks in the code on these type parameters that were able to happen at compile-time that now are done at run-time. I see about a 5-15% slowdown in common operations like `Parsers.parse(Int64, str)` and `Parsers.parse(Float64, str)`, but I also think if we really needed, we could get some of that back. Currently the default `Parsers.parse` codepath doesn't need a lot of the extra bells and whistles that other cases like json/csv parsing needs.

The main motivation here is `CSV.read` compile time and recompile time if you change one little parsing keyword arg. With no parameterization, we can essentially precompile parsing for each type once, and be done. It will also simplify a bunch of CSV.jl internals code because we don't need to worry about getting `Parsers.Options` specialized.

There is a current roadblock of sorts and that's the `dateformat` field of `Parsers.Options`. That's baked into the `Dates` stdlib and has its own full parameterization that we were "passing through" in the `Parsers.Options` `DF` parameter. What this means in real terms is that passing a custom `dateformat` string to `CSV.read` will probably be much slower. We can possibly look into ways around that, but the ultimate solution would probably involve a rewrite of the `Dates` parsing code to not rely on fully parameterizing format strings.

Anyway, I was pleasantly surprised at how easy of a change this was; I don't think we need to rush changing this, but it's at least useful to see that it's not too hard of a change, and to get a feel for what the performance impact would be.