### PR TITLE
Fix case when float parsing, we failed to check eof before peeking

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -291,6 +291,11 @@ end
         if negexp || b == UInt8('+')
             pos += 1
             incr!(source)
+            if eof(source, pos, len)
+                # it's an error to have a "dangling" '-' or '+', so input was something like "1.1e-"
+                code |= INVALID | EOF
+                @goto done
+            end
         end
         b = peekbyte(source, pos) - UInt8('0')
         if b > 0x09

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -363,4 +363,7 @@ for _ = 1:1000
     @test Base.parse(Float16, str) === Parsers.parse(Float16, str)
 end
 
+# discovered from JSON tests
+@test Parsers.tryparse(Float64, "0e+") === nothing
+
 end # @testset


### PR DESCRIPTION
Discovered while porting JSON.jl to Parsers 2.0. Unfortunately, the byte
peeking was under an `@inbounds`, so this usually wouldn't error unless
julia was run with `--check-bounds=yes` (which is the default when
running tests thankfully). Good candidate to backport for another 1.X
release.