### PR TITLE
Fix case where fallback Base.parse throws error

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -182,7 +182,7 @@ struct, `pos` which indicates the byte position where parsing should begin in a 
 buffer `source`. If parsing fails for any reason, either invalid value or non-value characters encountered before/after a value, `nothing` will be returned. To instead throw
 an error, use [`Parsers.parse`](@ref).
 """
-function tryparse(::Type{T}, buf::Union{AbstractVector{UInt8}, AbstractString, IO}, options=OPTIONS; pos::Integer=1, len::Integer=buf isa IO ? 0 : sizeof(buf)) where {T}
+function tryparse(::Type{T}, buf::Union{AbstractVector{UInt8}, AbstractString, IO}, options=OPTIONS, pos::Integer=1, len::Integer=buf isa IO ? 0 : sizeof(buf)) where {T}
     res = xparse2(T, buf isa AbstractString ? codeunits(buf) : buf, pos, len, options)
     fin = buf isa IO || (res.tlen == (len - pos + 1))
     return ok(res.code) && fin ? (res.val::T) : nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ struct CustomType
     x::String
 end
 
-Base.parse(::Type{CustomType}, x::String) = CustomType(x)
+Base.tryparse(::Type{CustomType}, x::String) = CustomType(x)
 
 @testset "Parsers" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -487,6 +487,11 @@ opts = Parsers.Options(sentinel=missings, trues=["true"])
 @test_throws ArgumentError Parsers.PosLen(1, Parsers.MAX_LEN + 1)
 @test_throws ArgumentError Parsers.PosLen(1, 1).invalidproperty
 
+# test invalid fallback parsing
+@test_throws Parsers.Error Parsers.parse(Complex{Float64}, "NaN+NaN*im")
+@test Parsers.tryparse(Complex{Float64}, "NaN+NaN*im") === nothing
+
+
 end # @testset "misc"
 
 include("floats.jl")


### PR DESCRIPTION
Should fix https://github.com/JuliaData/CSV.jl/issues/860. (probably
should backport this to 1.X branch).