### PR TITLE
Ensure all BigInts are initialized at __init__-time

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -857,8 +857,12 @@ include("ryu.jl")
 
 function __init__()
     # floats.jl globals
-    Threads.resize_nthreads!(BIGFLOAT)
-    Threads.resize_nthreads!(BIGINT)
+    if VERSION > v"1.5"
+        Threads.resize_nthreads!(BIGINT, BigInt(; nbits=256))
+    else
+        Threads.resize_nthreads!(BIGINT, BigInt())
+    end
+    Threads.resize_nthreads!(BIGFLOAT, BigFloat())
     return
 end
 

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -2,11 +2,7 @@ using Base.MPFR, Base.GMP, Base.GMP.MPZ
 
 _widen(x::UInt64) = UInt128(x)
 
-if VERSION > v"1.5"
-const BIGINT = [BigInt(; nbits=256)]
-else
-const BIGINT = [BigInt()]
-end
+const BIGINT = BigInt[]
 
 function _widen(v::UInt128)
     @inbounds x = BIGINT[Threads.threadid()]
@@ -451,7 +447,7 @@ end
 end
 
 const BIGEXP10 = [1 / exp10(BigInt(e)) for e = 309:326]
-const BIGFLOAT = [BigFloat()]
+const BIGFLOAT = BigFloat[]
 if VERSION > v"1.5"
 const BIGFLOATEXP10 = [exp10(BigFloat(i; precision=64)) for i = 1:308]
 else


### PR DESCRIPTION
Attempt to fix #87. My theory for what's going on here is that because
the `BIGINT` array is a global const like `const BIGINT = [BigInt()]`,
the internal pointers of the 1st `BigInt` element are becoming stale
once it goes through PackageCompiler. The proposed change here instead
sets the `BIGINT` global const as an _empty_ array, and then intializes
_all_ elements per thread during module `__init__` function.