### PR TITLE
Ensure high-precision floats don't default to Float64 for scaling

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -437,7 +437,10 @@ end
         x = v * V(1e23)
     elseif exp > 0
         x = v * exp10(exp)
-    elseif exp < -308
+    elseif exp < -308 || v > maxsig(T)
+        # if v is too large, we lose precision by just doing
+        # v / exp10(-exp) since that only promotes to Float64
+        # so detect and re-route to this branch where we widen v
         y = _widen(v)
         return _scale(T, y, exp, neg)
     else

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -366,4 +366,8 @@ end
 # discovered from JSON tests
 @test Parsers.tryparse(Float64, "0e+") === nothing
 
+# https://github.com/JuliaData/CSV.jl/issues/916
+@test  Parsers.parse(Float64, "0.44311945001372019574271437679879349172") === 0.4431194500137202
+@test Parsers.parse(BigFloat, "0.44311945001372019574271437679879349172") == BigFloat("0.44311945001372019574271437679879349172")
+
 end # @testset


### PR DESCRIPTION
The issue here is that in the `_scale` method where `v::UInt128`, `v`
might be so large as to lose precision when doing the `x = v /
exp10(-exp)` operation since `exp10(-exp)` will be a `Float64` and hence
our `v` will be promoted to `Float64` before dividing. That's fine if `v
< maxsig(T)`, like in the original `scale` method, but otherwise, we
need to widen `v` and do the division via `BigInt`.