### PR TITLE
Return the correct value when encoutering an invalid delimiter

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -491,6 +491,19 @@ opts = Parsers.Options(sentinel=missings, trues=["true"])
 @test_throws Parsers.Error Parsers.parse(Complex{Float64}, "NaN+NaN*im")
 @test Parsers.tryparse(Complex{Float64}, "NaN+NaN*im") === nothing
 
+# test we parse and return the correct value up to an invalid delimiter
+# https://github.com/JuliaData/Parsers.jl/issues/93
+for (T, str, val) in (
+    (Float64, "1.0 /", 1.0),
+    (Float64, "1.0 /[ 2.0 ]/", 1.0),
+    (Int, "2 _", 2),
+    (Date, "2021-10-20 *", Date("2021-10-20")),
+    (Bool, "false^", false),
+)
+    res = Parsers.xparse(T, str)
+    @test Parsers.invaliddelimiter(res.code)
+    @test res.val === val
+end
 
 end # @testset "misc"
 


### PR DESCRIPTION
- Changes `xparse` to always set the value in
  the returned `Result` to be the value returned
  by `typeparser`, and only leave the `Result`
  value unset if parsing completed before calling
  `typeparser`.
- `typeparser` already parses the correct value up
   to an invalid delimiter, so this just changes
   `xparse` to return that value when available.
- This should ensure that the `result.val` returned
  by `xparse` can be relied upon to even when
  `Parsers.invaliddelim(result.code) == true`.

closes #93 

Not sure if this is the best solution.
Also not sure if we should update some docs on what exactly can be relied upon.  
Currently the documentation states that `invalid(res.code)` (regardless the specific reason) means `res.val` cannot be relied upon, but perhaps we want to weaken that?
https://github.com/JuliaData/Parsers.jl/blob/6b560d4ec732fcd44a39c1a86cfe017062d6977c/src/Parsers.jl#L26
I think parsing and returning the correct value whenever possible is still a good change, even if we don't (or don't yet) want to give stronger guarantees in the documentation.