### PR TITLE
Allow setting of parsed value if typeparser succeeded

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -658,7 +658,7 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
 
 @label donedone
     tlen = pos - startpos
-    if ok(code)
+    if valueok(code)
         y::T = x
         return Result{S}(code, tlen, y)
     else
@@ -712,7 +712,7 @@ end
 
 @label donedone
     tlen = pos - startpos
-    return ok(code) ? Result{S}(code, tlen, x) : Result{S}(code, tlen)
+    return valueok(code) ? Result{S}(code, tlen, x) : Result{S}(code, tlen)
 end
 
 @inline function xparse2(::Type{T}, source, pos, len, options, ::Type{S}=T) where {T, S}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -63,6 +63,7 @@ const INVALID_DELIMITER    = 0b1000000010000000 % ReturnCode
 const OVERFLOW             = 0b1000000100000000 % ReturnCode
 const INVALID_TOKEN        = 0b1000010000000000 % ReturnCode
 
+valueok(x::ReturnCode) = (x & OK) == OK
 ok(x::ReturnCode) = (x & (OK | INVALID)) == OK
 invalid(x::ReturnCode) = x < SUCCESS
 sentinel(x::ReturnCode) = (x & SENTINEL) == SENTINEL

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -491,6 +491,19 @@ opts = Parsers.Options(sentinel=missings, trues=["true"])
 @test_throws Parsers.Error Parsers.parse(Complex{Float64}, "NaN+NaN*im")
 @test Parsers.tryparse(Complex{Float64}, "NaN+NaN*im") === nothing
 
+# test we parse and return the correct value up to an invalid delimiter
+# https://github.com/JuliaData/Parsers.jl/issues/93
+for (T, str, val) in (
+    (Float64, "1.0 /", 1.0),
+    (Float64, "1.0 /[ 2.0 ]/", 1.0),
+    (Int, "2 _", 2),
+    (Date, "2021-10-20 *", Date("2021-10-20")),
+    (Bool, "false^", false),
+)
+    res = Parsers.xparse(T, str)
+    @test Parsers.invaliddelimiter(res.code)
+    @test res.val === val
+end
 
 end # @testset "misc"
 


### PR DESCRIPTION
As pointed out by @nickrobinson251, if calling `typeparser` succeeds
(i.e. `(code & OK) == OK`), then we might as well set the correct value
in the parsing `Result` object. Up till now, if there was any `INVALID`
code invovled, `res.val` was undefined. With the proposed change in this
PR, we introduce a `Parsers.valueok(code)` function that can be checked,
and if true, then the user can know that a valid value was parsed and
can be accessed via `res.val`. Closes #93.