### PR TITLE
lazily allocate the threaded buffers and allocate them on the thread that will access it

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -856,13 +856,8 @@ include("dates.jl")
 include("ryu.jl")
 
 function __init__()
-    # floats.jl globals
-    if VERSION > v"1.5"
-        Threads.resize_nthreads!(BIGINT, BigInt(; nbits=256))
-    else
-        Threads.resize_nthreads!(BIGINT, BigInt())
-    end
-    Threads.resize_nthreads!(BIGFLOAT, BigFloat())
+    resize!(empty!(BIGINT), Threads.nthreads())
+    resize!(empty!(BIGFLOAT), Threads.nthreads())
     return
 end
 


### PR DESCRIPTION
Parsers.jl is a package that is a dependency of many popular packages. It is therefore of value to put some extra effort into improving its load time. This PR does the same as in HTTP https://github.com/JuliaWeb/HTTP.jl/pull/704 to improve load time (and allocating objects on the threads they are going to be used tends to be good for runtime performance as well).

Before:

```jl
julia> @time using Parsers
  0.122293 seconds (177.17 k allocations: 16.474 MiB, 9.22% gc time, 50.40% compilation time)
```

After:

```jl
julia> @time using Parsers
  0.071797 seconds (70.81 k allocations: 11.015 MiB, 12.59% gc time, 19.78% compilation time)
```