### PR TITLE
Fix bug when parsing consecutive, same-thread, non-negative, non-fast-path BigFloats

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -460,7 +460,7 @@ end
 function convert_and_apply_neg(::Type{BigFloat}, x::BigFloat, neg)
     y = unalias_bigfloat(x)
     if neg
-        ccall((:mpfr_neg, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, MPFR.MPFRRoundingMode), y, y, MPFR.ROUNDING_MODE[])
+        ccall((:mpfr_neg, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Int32), y, y, MPFR.ROUNDING_MODE[])
     end
     return y
 end

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -446,12 +446,12 @@ end
 end
 
 # Copied from https://github.com/JuliaLang/julia/blob/c054dbc6d4e03d7168864fed018e3635b546d251/base/mpfr.jl#L1029-L1031
-function copy_if_mutable(::Type{BigFloat}, x::BigFloat)
+function unalias_bigfloat(::Type{BigFloat}, x::BigFloat)
     d = x._d
     d′ = GC.@preserve d unsafe_string(pointer(d), sizeof(d)) # creates a definitely-new String
     return Base.MPFR._BigFloat(x.prec, x.sign, x.exp, d′)
 end
-copy_if_mutable(::Type{T}, x) where {T} = T(x)
+unalias_bigfloat(::Type{T}, x) where {T} = T(x)
 
 @inline function _scale(::Type{T}, v::V, exp, neg) where {T, V <: UInt128}
     if exp == 23
@@ -469,7 +469,7 @@ copy_if_mutable(::Type{T}, x) where {T} = T(x)
         x = v / exp10(-exp)
     end
     # See https://github.com/JuliaData/CSV.jl/issues/938
-    return neg ? T(-x) : copy_if_mutable(T, x)
+    return neg ? T(-x) : unalias_bigfloat(T, x)
 end
 
 const BIGEXP10 = [1 / exp10(BigInt(e)) for e = 309:327]
@@ -510,7 +510,7 @@ end
             x, x, y, MPFR.ROUNDING_MODE[])
     end
     # See https://github.com/JuliaData/CSV.jl/issues/938
-    return neg ? T(-x) : copy_if_mutable(T, x)
+    return neg ? T(-x) : unalias_bigfloat(T, x)
 end
 
 @inline function two_prod(a, b)

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -445,13 +445,25 @@ end
     return T(Core.bitcast(Float64, mantissa))
 end
 
+convert_and_apply_neg(::Type{T}, x, neg) where {T} = neg ? T(-x) : T(x)
+
 # Copied from https://github.com/JuliaLang/julia/blob/c054dbc6d4e03d7168864fed018e3635b546d251/base/mpfr.jl#L1029-L1031
-function unalias_bigfloat(::Type{BigFloat}, x::BigFloat)
+function unalias_bigfloat(x::BigFloat)
     d = x._d
     d′ = GC.@preserve d unsafe_string(pointer(d), sizeof(d)) # creates a definitely-new String
     return Base.MPFR._BigFloat(x.prec, x.sign, x.exp, d′)
 end
-unalias_bigfloat(::Type{T}, x) where {T} = T(x)
+
+# need to special-case here because `x` came from thread-local BIGFLOATS array
+# so we need to make a copy to get a fresh BigFloat
+# # See https://github.com/JuliaData/CSV.jl/issues/938
+function convert_and_apply_neg(::Type{BigFloat}, x::BigFloat, neg)
+    y = unalias_bigfloat(x)
+    if neg
+        ccall((:mpfr_neg, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, MPFR.MPFRRoundingMode), y, y, MPFR.ROUNDING_MODE[])
+    end
+    return y
+end
 
 @inline function _scale(::Type{T}, v::V, exp, neg) where {T, V <: UInt128}
     if exp == 23
@@ -468,8 +480,7 @@ unalias_bigfloat(::Type{T}, x) where {T} = T(x)
     else
         x = v / exp10(-exp)
     end
-    # See https://github.com/JuliaData/CSV.jl/issues/938
-    return neg ? T(-x) : unalias_bigfloat(T, x)
+    return convert_and_apply_neg(T, x, neg)
 end
 
 const BIGEXP10 = [1 / exp10(BigInt(e)) for e = 309:327]
@@ -509,8 +520,7 @@ end
             (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Int32),
             x, x, y, MPFR.ROUNDING_MODE[])
     end
-    # See https://github.com/JuliaData/CSV.jl/issues/938
-    return neg ? T(-x) : unalias_bigfloat(T, x)
+    return convert_and_apply_neg(T, x, neg)
 end
 
 @inline function two_prod(a, b)

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -374,4 +374,9 @@ end
 @test Parsers.parse(Float64,"9.3494547075363499E-311") === 9.3494547075363e-311
 @test Parsers.parse(Float64,"9.349454707536349999E-311") === 9.3494547075363e-311
 
+# https://github.com/JuliaData/CSV.jl/issues/938
+v1 = Parsers.parse(BigFloat, "0.994322841995507271075540969506")
+v2 = Parsers.parse(BigFloat, "0.794322841995507271075540969506")
+@test v1 !== v2
+
 end # @testset


### PR DESCRIPTION
Just one extra commit on top of @KristofferC's fix from #100 that refactors a tad so that we avoid making an extra BigFloat copy when parsing negative BigFloats.

I also studied all other return paths from `scale` and `_scale` to ensure the same issue can't be reached in any other way. As a mental note, we could probably speed up BigFloat parsing a bit, or at least avoid a few extra allocations, by either optimizing the fast-path for BigFloats, or just _avoiding_ the fast-path and letting them falldown to the already BigFloat-optimized code. As-is, we do the operation like `x = T(v) * pow10(T, exp)`, which allocates at least 2-3 BigFloats whereas we should be able to only do a single allocation.