### PR TITLE
Fix case where we have a dangling non-digit after integer in float parse

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -262,9 +262,11 @@ end
 
 @inline function parsefrac(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac) where {T <: SupportedFloats, IntType}
     x = zero(T)
+    parsedanyfrac = false
     # check if `b` is a digit
     if b - UInt8('0') < 0x0a
         b -= UInt8('0')
+        parsedanyfrac = true
         # if so, parse fractional digits
         while true
             digits = _muladd(ten(IntType), digits, b)
@@ -318,7 +320,11 @@ end
         return parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, UInt64(0), negexp)
     else
         # if no scientific notation, we're done, so scale digits + frac and return
-        x = scale(T, digits, -signed(frac), neg)
+        if parsedanyfrac
+            x = scale(T, digits, -signed(frac), neg)
+        else
+            x = ifelse(neg, -T(digits), T(digits))
+        end
         code |= OK
     end
 

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -379,4 +379,7 @@ v1 = Parsers.parse(BigFloat, "0.994322841995507271075540969506")
 v2 = Parsers.parse(BigFloat, "0.794322841995507271075540969506")
 @test v1 !== v2
 
+# parsing larger than Int64 with dangling non-digits
+@test_throws Parsers.Error Parsers.parse(Float64, "3130307457683247493156627A")
+
 end # @testset


### PR DESCRIPTION
Fixes issue reported on slack. The problem is that we have a code path
in `parsedigits` that exits early if we hit EOF and just converts the
integer string to the desired float type. But if there's a dangling
non-digit, like "123A", then we parse the "123" but then there may be
scientific notation or a decimal point, so we pass the parsing off to
the `parsefrac` function which handles both those cases. `parsefrac`
however, doesn't have the convert-integer-to-float return option, so we
pass the parsed digits and, in this case non-existent, `exp` number to
`scale` to "scale" the digits appropriately for the float case. `scale`
can normally handle an `exp` of `0`, _except_ in the case where the
`digits` are bigger than the `maxsig` allowed for `Float64`, in which
case it's converted to a `UInt128` and the `BigInt`/`BigFloat` code
takes care of the scaling. That's where the originally reported error
was happening because those "big" code paths weren't expecting an `exp`
of 0.

The solution proposed here is to avoid getting into the `scale` business
at all, since it's 1) more efficient and 2) we're basically still in the
state at the end of `parsedigits` where we've basically just parsed an
integer and can just convert it directly to the appropriate float type.