### PR TITLE
Successor to #104 for string value whitespace stripping

### DIFF
--- a/src/strings.jl
+++ b/src/strings.jl
@@ -1,6 +1,6 @@
 # this is mostly copy-pasta from Parsers.jl main xparse function
 function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, options, ::Type{S}=PosLen) where {T <: AbstractString, S}
-    startpos = vstartpos = vpos = pos
+    startpos = vstartpos = vpos = lastnonwhitespacepos = pos
     sentstart = sentinelpos = 0
     code = SUCCESS
     sentinel = options.sentinel
@@ -15,6 +15,9 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
         pos += 1
         incr!(source)
         vpos = pos
+        if options.stripwhitespace
+            vstartpos = pos
+        end
         if eof(source, pos, len)
             code |= EOF
             @goto donedone
@@ -40,6 +43,9 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
                 pos += 1
                 incr!(source)
                 vpos = pos
+                if options.stripwhitespace
+                    vstartpos = pos
+                end
                 if eof(source, pos, len)
                     code |= INVALID_QUOTED_FIELD | EOF
                     @goto donedone
@@ -53,7 +59,7 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
         sentstart = pos
         sentinelpos = checksentinel(source, pos, len, sentinel)
     end
-    vpos = pos
+    vpos = lastnonwhitespacepos = pos
     if options.quoted
         # for quoted fields, find the closing quote character
         if quoted
@@ -91,6 +97,9 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
                     code |= INVALID_QUOTED_FIELD | EOF
                     @goto donedone
                 end
+                if options.stripwhitespace && b != options.wh1 && b != options.wh2
+                    lastnonwhitespacepos = pos
+                end
                 b = peekbyte(source, pos)
             end
             b = peekbyte(source, pos)
@@ -108,7 +117,7 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
     end
     if options.delim !== nothing
         delim = options.delim
-        quo = Int(!quoted)
+        unquoted = Int(!quoted)
         # now we check for a delimiter; if we don't find it, keep parsing until we do
         while true
             if !options.ignorerepeated
@@ -227,7 +236,12 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
             end
             # didn't find delimiter nor newline, so increment and check the next byte
             pos += 1
-            vpos += quo
+            vpos += unquoted
+            if options.stripwhitespace
+                if b != options.wh1 && b != options.wh2
+                    lastnonwhitespacepos = vpos
+                end
+            end
             incr!(source)
             if eof(source, pos, len)
                 code |= EOF
@@ -258,6 +272,9 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
     end
     if eof(source, pos, len)
         code |= EOF
+    end
+    if options.stripwhitespace
+        vpos = lastnonwhitespacepos
     end
     poslen = PosLen(vstartpos, vpos - vstartpos, ismissing, escapedstring(code))
     tlen = pos - startpos

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -253,8 +253,14 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
         # no delimiter, so read until EOF
         while !eof(source, pos, len)
             pos += 1
-            vpos += 1
             incr!(source)
+            if options.stripwhitespace
+                b = peekbyte(source, pos)
+                if b != options.wh1 && b != options.wh2
+                    lastnonwhitespacepos = vpos
+                end
+            end
+            vpos += 1
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,6 +250,8 @@ res = Parsers.xparse(String, "hey there ,"; delim=',', stripwhitespace=true)
 @test res.val.pos == 1 && res.val.len == 9
 res = Parsers.xparse(String, " hey there "; stripwhitespace=true)
 @test res.val.pos == 2 && res.val.len == 9
+res = Parsers.xparse(String, " hey there "; delim=nothing, stripwhitespace=true)
+@test res.val.pos == 2 && res.val.len == 9
 
 end # @testset "Core Parsers.xparse"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,6 +195,13 @@ testcases = [
     (str="1\r\n#  \r\n\r\n", kwargs=(ignoreemptylines=true, comment="#",), x=1, code=(OK | NEWLINE | EOF), vpos=1, vlen=1, tlen=10),
     (str="1,\r\n#  \r\n\r\n,", kwargs=(ignorerepeated=true, ignoreemptylines=true, comment="#", delim=UInt8(',')), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=12),
     (str="1::\r\n#  \r\n\r\n::", kwargs=(ignorerepeated=true, ignoreemptylines=true, comment="#", delim="::"), x=1, code=(OK | NEWLINE | DELIMITED), vpos=1, vlen=1, tlen=14),
+    # stripwhitespace
+    (str=" 1", kwargs=(stripwhitespace=true,), x=1, code=(OK | EOF), vpos=2, vlen=1, tlen=2),
+    (str="{ 1}", kwargs=(stripwhitespace=true,), x=1, code=(OK | QUOTED | EOF), vpos=3, vlen=1, tlen=4),
+    (str="{1 }", kwargs=(stripwhitespace=true,), x=1, code=(OK | QUOTED | EOF), vpos=2, vlen=1, tlen=4),
+    (str="1 ", kwargs=(stripwhitespace=true,), x=1, code=(OK | EOF), vpos=1, vlen=1, tlen=2),
+    (str="1 ,", kwargs=(stripwhitespace=true,delim=UInt8(',')), x=1, code=(OK | DELIMITED), vpos=1, vlen=1, tlen=3),
+    (str="{1 } ,", kwargs=(stripwhitespace=true,delim=UInt8(',')), x=1, code=(OK | DELIMITED | QUOTED), vpos=2, vlen=1, tlen=6),
 ];
 
 for useio in (false, true)
@@ -229,6 +236,20 @@ for (i, case) in enumerate(testcases)
         @test tlen == case.tlen
     end
 end
+
+# stripwhitespace
+res = Parsers.xparse(String, "{hey there}"; openquotechar='{', closequotechar='}', stripwhitespace=true)
+@test res.val.pos == 2 && res.val.len == 9
+res = Parsers.xparse(String, "{hey there }"; openquotechar='{', closequotechar='}', stripwhitespace=true)
+@test res.val.pos == 2 && res.val.len == 9
+res = Parsers.xparse(String, "{hey there },"; openquotechar='{', closequotechar='}', delim=',', stripwhitespace=true)
+@test res.val.pos == 2 && res.val.len == 9
+res = Parsers.xparse(String, "{hey there } ,"; openquotechar='{', closequotechar='}', delim=',', stripwhitespace=true)
+@test res.val.pos == 2 && res.val.len == 9
+res = Parsers.xparse(String, "hey there ,"; delim=',', stripwhitespace=true)
+@test res.val.pos == 1 && res.val.len == 9
+res = Parsers.xparse(String, " hey there "; stripwhitespace=true)
+@test res.val.pos == 2 && res.val.len == 9
 
 end # @testset "Core Parsers.xparse"
 


### PR DESCRIPTION
Sorry if this is commandeering your PR @tp2750, but I figured I'd "top it off" for you if that's ok. I used/included your 1st commit in this PR, but did my own implementation in the strings.jl file for how the actual whitespace stripping happens. We needed to ensure it was correctly ignored inside quoted string values and if no delimiter was provided, in addition to the code you had which only considered the delimited case. I know the tests can seem a little intimidating, so I went ahead and added a bunch of test cases for the various quoted/delimited/non-delimited cases we want to check.