### PR TITLE
Fix corner cases with stripewhitescpace and quoted/delimited strings

### DIFF
--- a/src/strings.jl
+++ b/src/strings.jl
@@ -237,8 +237,11 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
             # didn't find delimiter nor newline, so increment and check the next byte
             pos += 1
             vpos += unquoted
+            if quoted
+                code |= INVALID_DELIMITER
+            end
             if options.stripwhitespace
-                if b != options.wh1 && b != options.wh2
+                if !quoted && b != options.wh1 && b != options.wh2
                     lastnonwhitespacepos = vpos
                 end
             end
@@ -249,14 +252,14 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
             end
             b = peekbyte(source, pos)
         end
-    else
+    elseif !quoted
         # no delimiter, so read until EOF
         while !eof(source, pos, len)
             pos += 1
             incr!(source)
             if options.stripwhitespace
                 b = peekbyte(source, pos)
-                if b != options.wh1 && b != options.wh2
+                if !quoted && b != options.wh1 && b != options.wh2
                     lastnonwhitespacepos = vpos
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,6 +246,10 @@ res = Parsers.xparse(String, "{hey there },"; openquotechar='{', closequotechar=
 @test res.val.pos == 2 && res.val.len == 9
 res = Parsers.xparse(String, "{hey there } ,"; openquotechar='{', closequotechar='}', delim=',', stripwhitespace=true)
 @test res.val.pos == 2 && res.val.len == 9
+res = Parsers.xparse(String, "{hey there } a,"; openquotechar='{', closequotechar='}', delim=',', stripwhitespace=true)
+@test res.val.pos == 2 && res.val.len == 9 && Parsers.invaliddelimiter(res.code)
+res = Parsers.xparse(String, "{hey there } a "; openquotechar='{', closequotechar='}', delim=nothing, stripwhitespace=true)
+@test res.val.pos == 2 && res.val.len == 9 && res.tlen == 13
 res = Parsers.xparse(String, "hey there ,"; delim=',', stripwhitespace=true)
 @test res.val.pos == 1 && res.val.len == 9
 res = Parsers.xparse(String, " hey there "; stripwhitespace=true)


### PR DESCRIPTION
Fixes #106. There were a couple of corner cases missed in the initial
stripwhitespace support for strings when quotes are involved. In
particular, if a string is quoted, then we want to remember the last
non-whitespace position _inside_ the quotes and _not_ update the
position outside the quotes. There were also a few invalid cases we
weren't marking correctly if non-whitespace-non-delimiter characters
were encountered in between close quote character and delimiter.