### PR TITLE
add precompile runs for xparse and xparse2

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -5,26 +5,39 @@ function _precompile_()
     precompile(Tuple{typeof(Parsers.parse), Type{Date}, String})
 
     options = Parsers.Options()
-    pos = 0
-    source = codeunits("a")
-    len = length(source)
-    for T in (Char, String)
-        Parsers.xparse(T, source, pos, len, options)
-        Parsers.xparse(T, source, pos, len, options, Any)
-        source = Vector(source)
-        Parsers.xparse(T, source, pos, len, options)
-        Parsers.xparse(T, source, pos, len, options, Any)
+    pos = 1
+    val = "a"
+    len = length(val)
+    for T in (Char, String), buf in (codeunits(val), Vector(codeunits(val)))
+        Parsers.xparse(T, buf, pos, len, options)
+        Parsers.xparse(T, buf, pos, len, options, Any)
     end
-    source = codeunits("123")
-    len = length(source)
-    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool)
-        Parsers.xparse(T, source, pos, len, options)
-        Parsers.xparse(T, source, pos, len, options, T)
-        Parsers.xparse(T, source, pos, len, options, Any)
-        source = Vector(source)
-        Parsers.xparse(T, source, pos, len, options)
-        Parsers.xparse(T, source, pos, len, options, T)
-        Parsers.xparse(T, source, pos, len, options, Any)
+
+    for T in (Char, Symbol), buf in (val, Vector(codeunits(val)))
+        Parsers.xparse2(T, buf, pos, len, options)
+        Parsers.xparse2(T, buf, pos, len, options, T)
+        Parsers.xparse2(T, buf, pos, len, options, Any)
+    end
+
+    val = "123"
+    len = length(val)
+    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool), 
+        buf in (codeunits(val), Vector(codeunits(val)))
+        Parsers.xparse(T, buf, pos, len, options)
+        Parsers.xparse(T, buf, pos, len, options, T)
+        Parsers.xparse(T, buf, pos, len, options, Any)
+    end
+    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool), 
+        buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
+        Parsers.xparse2(T, buf, pos, len, options)
+        Parsers.xparse2(T, buf, pos, len, options, T)
+        Parsers.xparse2(T, buf, pos, len, options, Any)
+    end
+    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime), 
+        buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
+        Parsers.parse(T, buf)
+        Parsers.parse(T, buf, options)
+        Parsers.tryparse(T, buf)
     end
 end
 _precompile_()

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,5 +3,28 @@ function _precompile_()
     precompile(Tuple{typeof(Parsers.parse), Type{Int64}, String})
     precompile(Tuple{typeof(Parsers.parse), Type{Float64}, String})
     precompile(Tuple{typeof(Parsers.parse), Type{Date}, String})
+
+    options = Parsers.Options()
+    pos = 0
+    source = codeunits("a")
+    len = length(source)
+    for T in (Char, String)
+        Parsers.xparse(T, source, pos, len, options)
+        Parsers.xparse(T, source, pos, len, options, Any)
+        source = Vector(source)
+        Parsers.xparse(T, source, pos, len, options)
+        Parsers.xparse(T, source, pos, len, options, Any)
+    end
+    source = codeunits("123")
+    len = length(source)
+    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool)
+        Parsers.xparse(T, source, pos, len, options)
+        Parsers.xparse(T, source, pos, len, options, T)
+        Parsers.xparse(T, source, pos, len, options, Any)
+        source = Vector(source)
+        Parsers.xparse(T, source, pos, len, options)
+        Parsers.xparse(T, source, pos, len, options, T)
+        Parsers.xparse(T, source, pos, len, options, Any)
+    end
 end
 _precompile_()

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -21,23 +21,26 @@ function _precompile_()
 
     val = "123"
     len = length(val)
-    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool), 
-        buf in (codeunits(val), Vector(codeunits(val)))
-        Parsers.xparse(T, buf, pos, len, options)
-        Parsers.xparse(T, buf, pos, len, options, T)
-        Parsers.xparse(T, buf, pos, len, options, Any)
+    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool)
+        for buf in (codeunits(val), Vector(codeunits(val)))
+            Parsers.xparse(T, buf, pos, len, options)
+            Parsers.xparse(T, buf, pos, len, options, T)
+            Parsers.xparse(T, buf, pos, len, options, Any)
+        end
     end
-    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool), 
-        buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
-        Parsers.xparse2(T, buf, pos, len, options)
-        Parsers.xparse2(T, buf, pos, len, options, T)
-        Parsers.xparse2(T, buf, pos, len, options, Any)
+    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool)
+        for buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
+            Parsers.xparse2(T, buf, pos, len, options)
+            Parsers.xparse2(T, buf, pos, len, options, T)
+            Parsers.xparse2(T, buf, pos, len, options, Any)
+        end
     end
-    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime), 
-        buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
-        Parsers.parse(T, buf)
-        Parsers.parse(T, buf, options)
-        Parsers.tryparse(T, buf)
+    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime)
+        for buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
+            Parsers.parse(T, buf)
+            Parsers.parse(T, buf, options)
+            Parsers.tryparse(T, buf)
+        end
     end
 end
 _precompile_()

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -8,9 +8,6 @@ function _precompile_()
     for T in (String, Int32, Int64, Float64, BigFloat, Dates.Date, Dates.DateTime, Bool)
         for buf in (codeunits(val), Vector(codeunits(val)))
             Parsers.xparse(T, buf, pos, len, options)
-            if !(T === String)
-                Parsers.xparse(T, buf, pos, len, options, T)
-            end
             Parsers.xparse(T, buf, pos, len, options, Any)
         end
     end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,46 +1,25 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    precompile(Tuple{typeof(Parsers.parse), Type{Int64}, String})
-    precompile(Tuple{typeof(Parsers.parse), Type{Float64}, String})
-    precompile(Tuple{typeof(Parsers.parse), Type{Date}, String})
 
     options = Parsers.Options()
     pos = 1
-    val = "a"
-    len = length(val)
-    for T in (Char, String), buf in (codeunits(val), Vector(codeunits(val)))
-        Parsers.xparse(T, buf, pos, len, options)
-        Parsers.xparse(T, buf, pos, len, options, Any)
-    end
-
-    for T in (Char, Symbol), buf in (val, Vector(codeunits(val)))
-        Parsers.xparse2(T, buf, pos, len, options)
-        Parsers.xparse2(T, buf, pos, len, options, T)
-        Parsers.xparse2(T, buf, pos, len, options, Any)
-    end
-
     val = "123"
     len = length(val)
-    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool)
+    for T in (String, Int32, Int64, Float64, BigFloat, Dates.Date, Dates.DateTime, Bool)
         for buf in (codeunits(val), Vector(codeunits(val)))
             Parsers.xparse(T, buf, pos, len, options)
-            Parsers.xparse(T, buf, pos, len, options, T)
+            if !(T === String)
+                Parsers.xparse(T, buf, pos, len, options, T)
+            end
             Parsers.xparse(T, buf, pos, len, options, Any)
         end
     end
-    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool)
+
+    for T in (Int32, Int64, Float64, BigFloat, Dates.Date, Dates.DateTime, Bool)
         for buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
-            Parsers.xparse2(T, buf, pos, len, options)
-            Parsers.xparse2(T, buf, pos, len, options, T)
-            Parsers.xparse2(T, buf, pos, len, options, Any)
+            Parsers.tryparse(T, buf, options)
         end
     end
-    for T in (Int8, Int16, Int32, Int64, Float16, Float32, Float64, BigFloat, Dates.Date, Dates.DateTime)
-        for buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
-            Parsers.parse(T, buf)
-            Parsers.parse(T, buf, options)
-            Parsers.tryparse(T, buf)
-        end
-    end
+
 end
 _precompile_()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -538,4 +538,7 @@ include("floats.jl")
 include("dates.jl")
 include("ryu.jl")
 
+# Cover precompile code
+Parsers._precompile_()
+
 end # @testset "Parsers"


### PR DESCRIPTION
This reduces ttfx of CSV.jl by 12 seconds in these benchmarks:

Current timing with main branches of Parsers.jl and CSV.jl:
```julia
julia> @time using CSV
  3.086746 seconds (6.63 M allocations: 375.584 MiB, 7.03% gc time, 88.55% compilation time)

julia> const input="""
       time,ping,label
       1,25.7,x
       2,31.8,y
       """
"time,ping,label\n1,25.7,x\n2,31.8,y\n"

julia> io = IOBuffer(input)
IOBuffer(data=UInt8[...], readable=true, writable=false, seekable=true, append=false, size=34, maxsize=Inf, ptr=1, mark=-1)

julia> @time file = CSV.File(io)
 17.450644 seconds (48.24 M allocations: 1.982 GiB, 6.00% gc time, 99.98% compilation time)
2-element CSV.File:
 CSV.Row: (time = 1, ping = 25.7, label = "x")
 CSV.Row: (time = 2, ping = 31.8, label = "y")
```

With this PR and main of CSV.jl:
```julia
julia> @time using CSV
  3.027161 seconds (6.59 M allocations: 385.136 MiB, 7.53% gc time, 90.56% compilation time)

julia> const input="""
       time,ping,label
       1,25.7,x
       2,31.8,y
       """
"time,ping,label\n1,25.7,x\n2,31.8,y\n"

julia> io = IOBuffer(input)
IOBuffer(data=UInt8[...], readable=true, writable=false, seekable=true, append=false, size=34, maxsize=Inf, ptr=1, mark=-1)

julia> @time file = CSV.File(io)
  5.894205 seconds (12.28 M allocations: 656.183 MiB, 4.75% gc time, 99.94% compilation time)
2-element CSV.File:
 CSV.Row: (time = 1, ping = 25.7, label = "x")
 CSV.Row: (time = 2, ping = 31.8, label = "y")
```

With the PR at CSV.jl:
```julia
julia> @time using CSV
  0.871332 seconds (2.21 M allocations: 136.379 MiB, 5.89% gc time, 78.47% compilation time)

julia> const input="""
       time,ping,label
       1,25.7,x
       2,31.8,y
       """
"time,ping,label\n1,25.7,x\n2,31.8,y\n"

julia> io = IOBuffer(input)
IOBuffer(data=UInt8[...], readable=true, writable=false, seekable=true, append=false, size=34, maxsize=Inf, ptr=1, mark=-1)

julia> @time file = CSV.File(io)
  5.757817 seconds (14.37 M allocations: 780.821 MiB, 4.84% gc time, 99.97% compilation time)
2-element CSV.File:
 CSV.Row: (time = 1, ping = 25.7, label = "x")
 CSV.Row: (time = 2, ping = 31.8, label = "y")
```
