### PR TITLE
Revert precompilation

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,22 +1,7 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-
-    options = Parsers.Options()
-    pos = 1
-    val = "123"
-    len = length(val)
-    for T in (String, Int32, Int64, Float64, BigFloat, Bool)
-        for buf in (codeunits(val), Vector(codeunits(val)))
-            Parsers.xparse(T, buf, pos, len, options)
-            Parsers.xparse(T, buf, pos, len, options, Any)
-        end
-    end
-
-    for T in (Int32, Int64, Float64, BigFloat, Bool)
-        for buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
-            Parsers.tryparse(T, buf, options)
-        end
-    end
-
+    precompile(Tuple{typeof(Parsers.parse), Type{Int64}, String})
+    precompile(Tuple{typeof(Parsers.parse), Type{Float64}, String})
+    precompile(Tuple{typeof(Parsers.parse), Type{Date}, String})
 end
 _precompile_()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -538,7 +538,4 @@ include("floats.jl")
 include("dates.jl")
 include("ryu.jl")
 
-# Cover precompile code
-Parsers._precompile_()
-
 end # @testset "Parsers"


### PR DESCRIPTION
This reverts the precompilation changes from #108; this has caused weird precompilation issues for CSV.jl, particularly for windows users transitioning from 1.6 -> 1.7. I'm not sure if there's something in Parsers.jl, or CSV.jl, or core Julia that changed or is unsafe or not precompile friendly, but I don't have the time right now to chase down rabbit holes, so better to just remove for now and we can try to add back later.