### PR TITLE
Always strip quoted `' '` and `'\t'` when `stripquoted=true`

### DIFF
--- a/src/strings.jl
+++ b/src/strings.jl
@@ -97,7 +97,8 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
                     code |= INVALID_QUOTED_FIELD | EOF
                     @goto donedone
                 end
-                if options.stripquoted && b != options.wh1 && b != options.wh2
+                # Always treat space ' ' and tab '\t' as whitespace when quoted
+                if options.stripquoted && b != options.wh1 && b != options.wh2 && b != UInt8(' ') && b != UInt8('\t')
                     lastnonwhitespacepos = pos
                 end
                 b = peekbyte(source, pos)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -279,6 +279,10 @@ res = Parsers.xparse(String, " hey there "; delim=nothing, stripquoted=true)
 res = Parsers.xparse(String, " hey there "; delim=nothing, stripquoted=true, stripwhitespace=false)
 @test res.val.pos == 2 && res.val.len == 9
 
+# https://github.com/JuliaData/Parsers.jl/issues/115
+res = Parsers.xparse(String, "{hey there } "; openquotechar='{', closequotechar='}', stripquoted=true, delim=' ', wh1=0x00)
+@test res.val.pos == 2 && res.val.len == 9
+
 end # @testset "Core Parsers.xparse"
 
 @testset "ints" begin


### PR DESCRIPTION
- closes #115 (see issue for details)
- ...but i'm not sure if hardcoding  `' '` and `'\t'` as whitespace (when in quotes) is a great idea
    - we do hardcode `'\n'` and `'\r'` as newline chars, which seems fairly analogous
    - but we do  expose `wh1` and `wh2` for whitespace
- an alternative is to expose `qwh1`, `qwh2` keywords for setting "chars to be considered leading/trailing whitespace in quoted strings", but it'd only be used in this one use-case, so i'm inclined to think we can wait til it's requested