### PR TITLE
Support Strings (multiple chars) as 'quotechars'

### DIFF
--- a/src/strings.jl
+++ b/src/strings.jl
@@ -98,7 +98,7 @@ function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, o
                     break
                 else
                     preqpos = pos
-                    pos = checkquote(source, pos, len, options.oq)
+                    pos = checkquote(source, pos, len, options.cq)
                     if pos > preqpos
                         if eof(source, pos, len)
                             code |= EOF

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -131,6 +131,7 @@ function checkdelim(source::IO, pos, len, (ptr, ptrlen))
     return delimpos
 end
 
+# if `true`, `source` incremented past the match, else not incremented
 @inline function match!(source::IO, ptr, ptrlen)
     b = peekbyte(source)
     c = unsafe_load(ptr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,7 +211,7 @@ for useio in (false, true)
         (UInt8('"'), UInt8('"'), UInt8('"')),
         (UInt8('"'), UInt8('"'), UInt8('\\')),
         (UInt8('{'), UInt8('}'), UInt8('\\')),
-        ("{{", "}}", UInt8('\\')),
+        ("#=", "=#", UInt8('\\')),
     )
         for (i, case) in enumerate(testcases)
             str = replace(replace(replace(case.str, '{'=>chars(oq)), '}'=>chars(cq)), '\\'=>chars(e))
@@ -223,8 +223,8 @@ for useio in (false, true)
                 @test x == case.x
             end
             @test code == case.code
-            if Parsers.invalidquotedfield(code) || Parsers.quoted(code)
-                @test tlen == length(str)
+            if Parsers.quoted(code)
+                @test tlen == ncodeunits(str)
             else
                 @test tlen == case.tlen
             end
@@ -249,8 +249,8 @@ for (i, case) in enumerate(testcases)
 end
 
 # stripwhitespace
-res = Parsers.xparse(String, "{{hey there }}"; openquotechar="{{", closequotechar="}}", stripwhitespace=true)
-@test res.val.pos == 3 && res.val.len == 11
+res = Parsers.xparse(String, "{{hey there}}"; openquotechar="{{", closequotechar="}}", stripwhitespace=true)
+@test res.val.pos == 3 && res.val.len == 9
 res = Parsers.xparse(String, "{hey there}"; openquotechar='{', closequotechar='}', stripwhitespace=true)
 @test res.val.pos == 2 && res.val.len == 9
 res = Parsers.xparse(String, "{hey there }"; openquotechar='{', closequotechar='}', stripwhitespace=true)
@@ -271,7 +271,7 @@ res = Parsers.xparse(String, " hey there "; delim=nothing, stripwhitespace=true)
 @test res.val.pos == 2 && res.val.len == 9
 
 res = Parsers.xparse(String, "{{hey there }}"; openquotechar="{{", closequotechar="}}", stripquoted=true)
-@test res.val.pos == 3 && res.val.len == 11
+@test res.val.pos == 3 && res.val.len == 9
 res = Parsers.xparse(String, "{hey there}"; openquotechar='{', closequotechar='}', stripquoted=true)
 @test res.val.pos == 2 && res.val.len == 9
 res = Parsers.xparse(String, "{hey there }"; openquotechar='{', closequotechar='}', stripquoted=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ testcases = [
     (str=" {\\\\", kwargs=(), x=0, code=(QUOTED | INVALID_QUOTED_FIELD | ESCAPED_STRING | EOF), vpos=3, vlen=0, tlen=4),
     (str=" {\\}} ", kwargs=(), x=0, code=(QUOTED | INVALID | ESCAPED_STRING | EOF), vpos=3, vlen=2, tlen=6),
     (str=" {\\\\}", kwargs=(), x=0, code=(INVALID | QUOTED | ESCAPED_STRING | EOF), vpos=3, vlen=2, tlen=5),
-    
+
     (str=" {}", kwargs=(), x=0, code=(INVALID | QUOTED | EOF), vpos=3, vlen=0, tlen=3),
     (str=" { }", kwargs=(), x=0, code=(INVALID | QUOTED | EOF), vpos=3, vlen=1, tlen=4),
     (str=" {,} ", kwargs=(), x=0, code=(INVALID | QUOTED | EOF), vpos=3, vlen=1, tlen=5),
@@ -253,6 +253,8 @@ res = Parsers.xparse(String, "{{hey there}}"; openquotechar="{{", closequotechar
 @test res.val.pos == 3 && res.val.len == 9
 res = Parsers.xparse(String, "{hey there}"; openquotechar='{', closequotechar='}', stripwhitespace=true)
 @test res.val.pos == 2 && res.val.len == 9
+res = Parsers.xparse(String, "{{hey there }}"; openquotechar="{{", closequotechar="}}", stripwhitespace=true)
+@test res.val.pos == 3 && res.val.len == 10
 res = Parsers.xparse(String, "{hey there }"; openquotechar='{', closequotechar='}', stripwhitespace=true)
 @test res.val.pos == 2 && res.val.len == 10
 res = Parsers.xparse(String, "{hey there },"; openquotechar='{', closequotechar='}', delim=',', stripwhitespace=true)
@@ -270,10 +272,12 @@ res = Parsers.xparse(String, " hey there "; stripwhitespace=true)
 res = Parsers.xparse(String, " hey there "; delim=nothing, stripwhitespace=true)
 @test res.val.pos == 2 && res.val.len == 9
 
-res = Parsers.xparse(String, "{{hey there }}"; openquotechar="{{", closequotechar="}}", stripquoted=true)
+res = Parsers.xparse(String, "{{hey there}}"; openquotechar="{{", closequotechar="}}", stripquoted=true)
 @test res.val.pos == 3 && res.val.len == 9
 res = Parsers.xparse(String, "{hey there}"; openquotechar='{', closequotechar='}', stripquoted=true)
 @test res.val.pos == 2 && res.val.len == 9
+res = Parsers.xparse(String, "{{hey there }}"; openquotechar="{{", closequotechar="}}", stripquoted=true)
+@test res.val.pos == 3 && res.val.len == 9
 res = Parsers.xparse(String, "{hey there }"; openquotechar='{', closequotechar='}', stripquoted=true)
 @test res.val.pos == 2 && res.val.len == 9
 res = Parsers.xparse(String, "{hey there },"; openquotechar='{', closequotechar='}', delim=',', stripquoted=true)


### PR DESCRIPTION
- Allow "quotechar" to actaully be a string, so that we can parse e.g. `#= text here =#" `to `"text here"`
- WIP til we decide if this is useful 
- Not entirely sure this is a good idea... motivation is parsing trailing end-of-line comments as an extra column (https://github.com/nickrobinson251/PowerFlowData.jl/issues/27)