### PR TITLE
Fix corner case of very large integer parsing that promotes to BigInt

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -475,7 +475,7 @@ function _scale(::Type{T}, v::V, exp, neg) where {T, V <: UInt128}
     if exp == 23
         # special-case concluded from https://github.com/JuliaLang/julia/issues/38509
         x = v * V(1e23)
-    elseif exp > 0
+    elseif exp >= 0
         x = v * exp10(exp)
     elseif exp < -308 || v > maxsig(T)
         # if v is too large, we lose precision by just doing

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -382,4 +382,7 @@ v2 = Parsers.parse(BigFloat, "0.794322841995507271075540969506")
 # parsing larger than Int64 with dangling non-digits
 @test_throws Parsers.Error Parsers.parse(Float64, "3130307457683247493156627A")
 
+# https://github.com/JuliaData/CSV.jl/issues/1007
+@test Parsers.parse(Float64, "19129370688824811353f0") === 1.912937068882481e19
+
 end # @testset


### PR DESCRIPTION
Fixes https://github.com/JuliaData/CSV.jl/issues/1007. The issue here is there's
actually a git sha "19129370688824811353f0bcee35b917" where the multithreaded
CSV.File case was trying to detect if this value was a float or not. But attempting
to call `Parsers.xparse` threw an error, which shouldn't happen from the Parsers.xparse
code path (it should just return an error code in the parsing result). The problem
was it parsed the very large integer 19129370688824811353, then `f` which it treated
as the exponenent character, then `0` as the exponent. When it went to do the scaling
code, it promoted the integer to `BigInt`, but the `_scale` BigInt path didn't
handle `0` exponent form. This is easily handled before we promote to `BigInt`
since we're really just looking to convert the large integer to the desired type.