### PR TITLE
ensure that `getstring` resets the position of IO

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -346,10 +346,12 @@ _unsafe_string(p, len) = ccall(:jl_pchar_to_string, Ref{String}, (Ptr{UInt8}, In
     if source isa AbstractVector{UInt8}
         return _unsafe_string(pointer(source, x.pos), x.len)
     else
+        pos = position(source)
         vpos, vlen = x.pos, x.len
         fastseek!(source, vpos - 1)
         str = Base.StringVector(vlen)
         readbytes!(source, str, vlen)
+        fastseek!(source, pos) # reset IO to earlier position
         return String(str)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ testcases = [
     (str=" {\\\\", kwargs=(), x=0, code=(QUOTED | INVALID_QUOTED_FIELD | ESCAPED_STRING | EOF), vpos=3, vlen=0, tlen=4),
     (str=" {\\}} ", kwargs=(), x=0, code=(QUOTED | INVALID | ESCAPED_STRING | EOF), vpos=3, vlen=2, tlen=6),
     (str=" {\\\\}", kwargs=(), x=0, code=(INVALID | QUOTED | ESCAPED_STRING | EOF), vpos=3, vlen=2, tlen=5),
-    
+
     (str=" {}", kwargs=(), x=0, code=(INVALID | QUOTED | EOF), vpos=3, vlen=0, tlen=3),
     (str=" { }", kwargs=(), x=0, code=(INVALID | QUOTED | EOF), vpos=3, vlen=1, tlen=4),
     (str=" {,} ", kwargs=(), x=0, code=(INVALID | QUOTED | EOF), vpos=3, vlen=1, tlen=5),
@@ -557,6 +557,15 @@ for (T, str, val) in (
     @test Parsers.invaliddelimiter(res.code)
     @test res.val === val
 end
+
+# test `getstring` does not change the position of a stream
+source = IOBuffer("\"str1\" \"str2\"")
+opt = Parsers.Options(; quoted=true)
+res = Parsers.xparse(String, source, 1, 0, opt)
+@test Parsers.getstring(source, res.val, opt.e) == "str1"
+res = Parsers.xparse(String, source, 1 + res.tlen, 0, opt)
+@test Parsers.getstring(source, res.val, opt.e) == "str2"
+
 
 end # @testset "misc"
 


### PR DESCRIPTION
Before this PR, this happened:

```jl
julia> source = IOBuffer("\"str1\" \"str2\"");

julia> opt = Parsers.Options(; quoted=true);

julia> res = Parsers.xparse(String, source, 1, 0, opt);
Parsers.Result{PosLen}(5, 7, PosLen(0x0000000000200004))

julia> @test Parsers.getstring(source, res.val, opt.e) == "str1"
Test Passed

julia> res = Parsers.xparse(String, source, 1 + res.tlen, 0, opt)
Parsers.Result{PosLen}(5, 3, PosLen(0x0000000000900001))

julia> @test Parsers.getstring(source, res.val, opt.e) == "str2"
Test Failed at REPL[7]:1
  Expression: Parsers.getstring(source, res.val, opt.e) == "str2"
   Evaluated: "s" == "str2"
ERROR: There was an error during testing
```