### PR TITLE
Introduce `groupmark` number-parsing option

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -139,11 +139,11 @@ function Options(
         push!(refs, comment)
         cmt = ptrlen(comment)
     end
-    if !isnothing(groupmark) && ((groupmark == decimal || isnumeric(groupmark)) || (delim == groupmark && !quoted) || (oq == groupmark) || (cq == groupmark))
+    if groupmark !== nothing && (groupmark == decimal || isnumeric(groupmark) || (delim == groupmark && !quoted) || (oq == groupmark) || (cq == groupmark))
         throw(ArgumentError("`groupmark` cannot be a number, a quoting char, coincide with `decimal` and `delim` unless `quoted=true`."))
     end
     df = dateformat === nothing ? nothing : dateformat isa String ? Format(dateformat) : dateformat isa Dates.DateFormat ? Format(dateformat) : dateformat
-    return Options(refs, sent, ignorerepeated, ignoreemptylines, wh1 % UInt8, wh2 % UInt8, quoted, oq % UInt8, cq % UInt8, e % UInt8, del, decimal % UInt8, trues, falses, df, cmt, stripwhitespace || stripquoted, stripquoted, isnothing(groupmark) ? nothing : UInt8(groupmark))
+    return Options(refs, sent, ignorerepeated, ignoreemptylines, wh1 % UInt8, wh2 % UInt8, quoted, oq % UInt8, cq % UInt8, e % UInt8, del, decimal % UInt8, trues, falses, df, cmt, stripwhitespace || stripquoted, stripquoted, groupmark === nothing ? nothing : UInt8(groupmark))
 end
 
 Options(;

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -55,7 +55,7 @@ end
   * `ignoreemptylines=false`: after parsing a value, if a newline is detected, another immediately proceeding newline will be checked for and consumed
   * `stripwhitespace=false`: if true, leading and trailing whitespace is stripped from string fields, note that for *quoted* strings however, whitespace is preserved within quotes (but ignored before/after quote characters). To also strip *within* quotes, see `stripquoted`
   * `stripquoted=false`: if true, whitespace is also stripped within quoted strings. If true, `stripwhitespace` is also set to true.
-  * `debug=false`: if `true`, various debug logging statements will be printed while parsing; useful when diagnosing why parsing returns certain `Parsers.ReturnCode` values
+  * `groupmark=nothing`: optionally specify a single-byte character denoting the number grouping mark, this llows parsing of numbers that have thousand separators.
 """
 struct Options
     refs::Vector{String} # for holding references to sentinel, trues, falses, cmt strings
@@ -76,6 +76,7 @@ struct Options
     cmt::Union{Nothing, PtrLen}
     stripwhitespace::Bool
     stripquoted::Bool
+    groupmark::Union{Nothing,UInt8}
 end
 
 prepare(x::Vector{String}) = sort!(map(ptrlen, x), by=x->x[2], rev=true)
@@ -94,7 +95,10 @@ function Options(
             trues::Union{Nothing, Vector{String}},
             falses::Union{Nothing, Vector{String}},
             dateformat::Union{Nothing, String, Dates.DateFormat, Format},
-            ignorerepeated, ignoreemptylines, comment, quoted, debug, stripwhitespace=false, stripquoted=false)
+            ignorerepeated, ignoreemptylines, comment, quoted,
+            stripwhitespace=false, stripquoted=false,
+            groupmark::Union{Nothing,Char,UInt8}=nothing,
+    )
     asciival(wh1) && asciival(wh2) || throw(ArgumentError("whitespace characters must be ASCII"))
     asciival(oq) && asciival(cq) && asciival(e) || throw(ArgumentError("openquotechar, closequotechar, and escapechar must be ASCII characters"))
     (oq == delim) || (cq == delim) || (e == delim) && throw(ArgumentError("delim argument must be different than openquotechar, closequotechar, and escapechar arguments"))
@@ -135,8 +139,11 @@ function Options(
         push!(refs, comment)
         cmt = ptrlen(comment)
     end
+    if !isnothing(groupmark) && (groupmark == decimal || isnumeric(groupmark))
+        throw(ArgumentError("`groupmark` cannot coincide with `decimal` and it must not be a number"))
+    end
     df = dateformat === nothing ? nothing : dateformat isa String ? Format(dateformat) : dateformat isa Dates.DateFormat ? Format(dateformat) : dateformat
-    return Options(refs, sent, ignorerepeated, ignoreemptylines, wh1 % UInt8, wh2 % UInt8, quoted, oq % UInt8, cq % UInt8, e % UInt8, del, decimal % UInt8, trues, falses, df, cmt, stripwhitespace || stripquoted, stripquoted)
+    return Options(refs, sent, ignorerepeated, ignoreemptylines, wh1 % UInt8, wh2 % UInt8, quoted, oq % UInt8, cq % UInt8, e % UInt8, del, decimal % UInt8, trues, falses, df, cmt, stripwhitespace || stripquoted, stripquoted, isnothing(groupmark) ? nothing : UInt8(groupmark))
 end
 
 Options(;
@@ -155,13 +162,13 @@ Options(;
     ignoreemptylines::Bool=false,
     comment::Union{Nothing, String}=nothing,
     quoted::Bool=false,
-    debug::Bool=false,
     stripwhitespace::Bool=false,
     stripquoted::Bool=false,
-) = Options(sentinel, wh1, wh2, openquotechar, closequotechar, escapechar, delim, decimal, trues, falses, dateformat, ignorerepeated, ignoreemptylines, comment, quoted, debug, stripwhitespace, stripquoted)
+    groupmark::Union{Nothing,Char,UInt8}=nothing,
+) = Options(sentinel, wh1, wh2, openquotechar, closequotechar, escapechar, delim, decimal, trues, falses, dateformat, ignorerepeated, ignoreemptylines, comment, quoted, stripwhitespace, stripquoted, groupmark)
 
-const OPTIONS = Options(nothing, UInt8(' '), UInt8('\t'), UInt8('"'), UInt8('"'), UInt8('"'), nothing, UInt8('.'), nothing, nothing, nothing, false, false, nothing, false, false, false)
-const XOPTIONS = Options(missing, UInt8(' '), UInt8('\t'), UInt8('"'), UInt8('"'), UInt8('"'), UInt8(','), UInt8('.'), nothing, nothing, nothing, false, false, nothing, true, false, false)
+const OPTIONS = Options(nothing, UInt8(' '), UInt8('\t'), UInt8('"'), UInt8('"'), UInt8('"'), nothing, UInt8('.'), nothing, nothing, nothing, false, false, nothing, false, false, false, nothing)
+const XOPTIONS = Options(missing, UInt8(' '), UInt8('\t'), UInt8('"'), UInt8('"'), UInt8('"'), UInt8(','), UInt8('.'), nothing, nothing, nothing, false, false, nothing, true, false, false, nothing)
 
 # high-level convenience functions like in Base
 """
@@ -209,8 +216,8 @@ A [`Parsers.Result`](@ref) struct is returned, with the following fields:
 function xparse end
 
 # for testing purposes only, it's much too slow to dynamically create Options for every xparse call
-function xparse(::Type{T}, buf::Union{AbstractVector{UInt8}, AbstractString, IO}; pos::Integer=1, len::Integer=buf isa IO ? 0 : sizeof(buf), sentinel=nothing, wh1::Union{UInt8, Char}=UInt8(' '), wh2::Union{UInt8, Char}=UInt8('\t'), quoted::Bool=true, openquotechar::Union{UInt8, Char}=UInt8('"'), closequotechar::Union{UInt8, Char}=UInt8('"'), escapechar::Union{UInt8, Char}=UInt8('"'), ignorerepeated::Bool=false, ignoreemptylines::Bool=false, delim::Union{UInt8, Char, PtrLen, AbstractString, Nothing}=UInt8(','), decimal::Union{UInt8, Char}=UInt8('.'), comment=nothing, trues=nothing, falses=nothing, dateformat::Union{Nothing, String, Dates.DateFormat}=nothing, debug::Bool=false, stripwhitespace::Bool=false, stripquoted::Bool=false) where {T}
-    options = Options(sentinel, wh1, wh2, openquotechar, closequotechar, escapechar, delim, decimal, trues, falses, dateformat, ignorerepeated, ignoreemptylines, comment, quoted, debug, stripwhitespace, stripquoted)
+function xparse(::Type{T}, buf::Union{AbstractVector{UInt8}, AbstractString, IO}; pos::Integer=1, len::Integer=buf isa IO ? 0 : sizeof(buf), sentinel=nothing, wh1::Union{UInt8, Char}=UInt8(' '), wh2::Union{UInt8, Char}=UInt8('\t'), quoted::Bool=true, openquotechar::Union{UInt8, Char}=UInt8('"'), closequotechar::Union{UInt8, Char}=UInt8('"'), escapechar::Union{UInt8, Char}=UInt8('"'), ignorerepeated::Bool=false, ignoreemptylines::Bool=false, delim::Union{UInt8, Char, PtrLen, AbstractString, Nothing}=UInt8(','), decimal::Union{UInt8, Char}=UInt8('.'), comment=nothing, trues=nothing, falses=nothing, dateformat::Union{Nothing, String, Dates.DateFormat}=nothing, stripwhitespace::Bool=false, stripquoted::Bool=false, groupmark=nothing) where {T}
+    options = Options(sentinel, wh1, wh2, openquotechar, closequotechar, escapechar, delim, decimal, trues, falses, dateformat, ignorerepeated, ignoreemptylines, comment, quoted, stripwhitespace, stripquoted, groupmark)
     return xparse(T, buf, pos, len, options)
 end
 

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -55,7 +55,7 @@ end
   * `ignoreemptylines=false`: after parsing a value, if a newline is detected, another immediately proceeding newline will be checked for and consumed
   * `stripwhitespace=false`: if true, leading and trailing whitespace is stripped from string fields, note that for *quoted* strings however, whitespace is preserved within quotes (but ignored before/after quote characters). To also strip *within* quotes, see `stripquoted`
   * `stripquoted=false`: if true, whitespace is also stripped within quoted strings. If true, `stripwhitespace` is also set to true.
-  * `groupmark=nothing`: optionally specify a single-byte character denoting the number grouping mark, this allows parsing of numbers that have, e.g., thousand separators.
+  * `groupmark=nothing`: optionally specify a single-byte character denoting the number grouping mark, this allows parsing of numbers that have, e.g., thousand separators (`1,000.00`).
 """
 struct Options
     refs::Vector{String} # for holding references to sentinel, trues, falses, cmt strings

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -55,7 +55,7 @@ end
   * `ignoreemptylines=false`: after parsing a value, if a newline is detected, another immediately proceeding newline will be checked for and consumed
   * `stripwhitespace=false`: if true, leading and trailing whitespace is stripped from string fields, note that for *quoted* strings however, whitespace is preserved within quotes (but ignored before/after quote characters). To also strip *within* quotes, see `stripquoted`
   * `stripquoted=false`: if true, whitespace is also stripped within quoted strings. If true, `stripwhitespace` is also set to true.
-  * `groupmark=nothing`: optionally specify a single-byte character denoting the number grouping mark, this llows parsing of numbers that have thousand separators.
+  * `groupmark=nothing`: optionally specify a single-byte character denoting the number grouping mark, this allows parsing of numbers that have, e.g., thousand separators.
 """
 struct Options
     refs::Vector{String} # for holding references to sentinel, trues, falses, cmt strings
@@ -139,8 +139,8 @@ function Options(
         push!(refs, comment)
         cmt = ptrlen(comment)
     end
-    if !isnothing(groupmark) && (groupmark == decimal || isnumeric(groupmark))
-        throw(ArgumentError("`groupmark` cannot coincide with `decimal` and it must not be a number"))
+    if !isnothing(groupmark) && ((groupmark == decimal || isnumeric(groupmark)) || (delim == groupmark && !quoted) || (oq == groupmark) || (cq == groupmark))
+        throw(ArgumentError("`groupmark` cannot be a number, a quoting char, coincide with `decimal` and `delim` unless `quoted=true`."))
     end
     df = dateformat === nothing ? nothing : dateformat isa String ? Format(dateformat) : dateformat isa Dates.DateFormat ? Format(dateformat) : dateformat
     return Options(refs, sent, ignorerepeated, ignoreemptylines, wh1 % UInt8, wh2 % UInt8, quoted, oq % UInt8, cq % UInt8, e % UInt8, del, decimal % UInt8, trues, falses, df, cmt, stripwhitespace || stripquoted, stripquoted, isnothing(groupmark) ? nothing : UInt8(groupmark))

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -203,7 +203,12 @@ end
                 code |= OK | EOF
                 @goto done
             end
-            b = peekbyte(source, pos) - UInt8('0')
+            b, nb = dpeekbyte(source, pos) .- UInt8('0')
+            if !isnothing(options.groupmark) && options.groupmark - UInt8('0') == b && nb <= 0x09
+                incr!(source)
+                pos += 1
+                b = nb
+            end
             # if `b` isn't a digit, time to break out of digit parsing while loop
             b > 0x09 && break
             if overflows(IntType) && digits > overflowval(IntType)

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -189,7 +189,7 @@ end
 @inline function parsedigits(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos) where {T <: SupportedFloats, IntType}
     x = zero(T)
     ndigits = 0
-    has_groupmark = !isnothing(options.groupmark)
+    has_groupmark = options.groupmark !== nothing
     # we already previously checked if `b` was decimal or a digit, so don't need to check explicitly again
     if b != options.decimal
         b -= UInt8('0')

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -189,6 +189,7 @@ end
 @inline function parsedigits(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos) where {T <: SupportedFloats, IntType}
     x = zero(T)
     ndigits = 0
+    has_groupmark = !isnothing(options.groupmark)
     # we already previously checked if `b` was decimal or a digit, so don't need to check explicitly again
     if b != options.decimal
         b -= UInt8('0')
@@ -203,11 +204,15 @@ end
                 code |= OK | EOF
                 @goto done
             end
-            b, nb = dpeekbyte(source, pos) .- UInt8('0')
-            if !isnothing(options.groupmark) && options.groupmark - UInt8('0') == b && nb <= 0x09
-                incr!(source)
-                pos += 1
-                b = nb
+            if has_groupmark
+                b, nb = dpeekbyte(source, pos) .- UInt8('0')
+                if options.groupmark - UInt8('0') == b && nb <= 0x09
+                    incr!(source)
+                    pos += 1
+                    b = nb
+                end
+            else
+                b = peekbyte(source, pos) - UInt8('0')
             end
             # if `b` isn't a digit, time to break out of digit parsing while loop
             b > 0x09 && break

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -32,7 +32,12 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
             code |= OK | EOF
             @goto done
         end
-        b = peekbyte(source, pos) - UInt8('0')
+        b, nb = dpeekbyte(source, pos) .- UInt8('0')
+        if !isnothing(options.groupmark) && options.groupmark - UInt8('0') == b && nb <= 0x09
+            incr!(source)
+            pos += 1
+            b = nb
+        end
         if b > 0x09
             # detected a non-digit, time to bail on value parsing
             x = ifelse(neg, -x, x)
@@ -66,7 +71,12 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
             code |= OK | EOF
             @goto done
         end
-        b = peekbyte(source, pos) - UInt8('0')
+        b, nb = dpeekbyte(source, pos) .- UInt8('0')
+        if !isnothing(options.groupmark) && options.groupmark - UInt8('0') == b && nb <= 0x09
+            incr!(source)
+            pos += 1
+            b = nb
+        end
         if b > 0x09
             code |= OK
             @goto done

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -7,7 +7,7 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
 @inline function typeparser(::Type{T}, source, pos, len, b, code, options) where {T <: Integer}
     x = zero(T)
     neg = false
-    has_groupmark = !isnothing(options.groupmark)
+    has_groupmark = options.groupmark !== nothing
     # start actual int parsing
     neg = b == UInt8('-')
     if neg || b == UInt8('+')

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -223,7 +223,7 @@ function peekbyte(from::IOBuffer)
 end
 function dpeekbyte(from::IOBuffer)
     @inbounds byte = from.data[from.ptr]
-    return byte, get(from.data, from.ptr+1, EOF_CHAR)
+    return byte, from.ptr >= from.size ? EOF_CHAR : @inbounds from.data[from.ptr+1]
 end
 
 function incr!(from::IOBuffer)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -63,7 +63,7 @@ const INVALID_DELIMITER    = 0b1000000010000000 % ReturnCode
 const OVERFLOW             = 0b1000000100000000 % ReturnCode
 const INVALID_TOKEN        = 0b1000010000000000 % ReturnCode
 
-const EOF_CHAR = 0xFF
+const EOF_BYTE = 0xFF
 
 valueok(x::ReturnCode) = (x & OK) == OK
 ok(x::ReturnCode) = (x & (OK | INVALID)) == OK
@@ -196,11 +196,10 @@ function peekbyte end
 incr!(io::IO) = readbyte(io)
 readbyte(from::IO) = Base.read(from, UInt8)
 peekbyte(from::IO) = UInt8(Base.peek(from))
-# dpeekbyte(from::IO) = (p = Base.peek(from, UInt16); (UInt8(p % UInt8), UInt8(p >> 8)))
 function dpeekbyte(s::IO) where T
     mark(s)
-    b = EOF_CHAR
-    nb = EOF_CHAR
+    b = EOF_BYTE
+    nb = EOF_BYTE
     try
         b = read(s, UInt8)::UInt8
         nb = read(s, UInt8)::UInt8
@@ -223,7 +222,7 @@ function peekbyte(from::IOBuffer)
 end
 function dpeekbyte(from::IOBuffer)
     @inbounds byte = from.data[from.ptr]
-    return byte, from.ptr >= from.size ? EOF_CHAR : @inbounds from.data[from.ptr+1]
+    return byte, from.ptr >= from.size ? EOF_BYTE : @inbounds from.data[from.ptr+1]
 end
 
 function incr!(from::IOBuffer)
@@ -240,7 +239,7 @@ function peekbyte(from::AbstractVector{UInt8}, pos)
 end
 function dpeekbyte(from::AbstractVector{UInt8}, pos)
     @inbounds b = from[pos]
-    return b, get(from, pos+1, EOF_CHAR)
+    return b, get(from, pos+1, EOF_BYTE)
 end
 
 eof(::AbstractVector{UInt8}, pos::Integer, len::Integer) = pos > len

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -63,6 +63,8 @@ const INVALID_DELIMITER    = 0b1000000010000000 % ReturnCode
 const OVERFLOW             = 0b1000000100000000 % ReturnCode
 const INVALID_TOKEN        = 0b1000010000000000 % ReturnCode
 
+const EOF_CHAR = 0xFF
+
 valueok(x::ReturnCode) = (x & OK) == OK
 ok(x::ReturnCode) = (x & (OK | INVALID)) == OK
 invalid(x::ReturnCode) = x < SUCCESS
@@ -194,6 +196,19 @@ function peekbyte end
 incr!(io::IO) = readbyte(io)
 readbyte(from::IO) = Base.read(from, UInt8)
 peekbyte(from::IO) = UInt8(Base.peek(from))
+# dpeekbyte(from::IO) = (p = Base.peek(from, UInt16); (UInt8(p % UInt8), UInt8(p >> 8)))
+function dpeekbyte(s::IO) where T
+    mark(s)
+    b = EOF_CHAR
+    nb = EOF_CHAR
+    try
+        b = read(s, UInt8)::UInt8
+        nb = read(s, UInt8)::UInt8
+    finally
+        reset(s)
+    end
+    return (b, nb)
+end
 
 function readbyte(from::IOBuffer)
     i = from.ptr
@@ -206,6 +221,10 @@ function peekbyte(from::IOBuffer)
     @inbounds byte = from.data[from.ptr]
     return byte
 end
+function dpeekbyte(from::IOBuffer)
+    @inbounds byte = from.data[from.ptr]
+    return byte, get(from.data, from.ptr+1, EOF_CHAR)
+end
 
 function incr!(from::IOBuffer)
     from.ptr += 1
@@ -214,9 +233,14 @@ end
 
 incr!(::AbstractVector{UInt8}) = nothing
 peekbyte(from::IO, pos) = peekbyte(from)
+dpeekbyte(from::IO, pos) = dpeekbyte(from)
 function peekbyte(from::AbstractVector{UInt8}, pos)
     @inbounds b = from[pos]
     return b
+end
+function dpeekbyte(from::AbstractVector{UInt8}, pos)
+    @inbounds b = from[pos]
+    return b, get(from, pos+1, EOF_CHAR)
 end
 
 eof(::AbstractVector{UInt8}, pos::Integer, len::Integer) = pos > len

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -368,20 +368,41 @@ end
 
 @testset "groupmark" begin
     @test Parsers.xparse(Float64, "100,000,000.99"; groupmark=',').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "100,000,000"; groupmark=',').val == 100_000_000.0
     @test Parsers.xparse(Float64, "1,0,0,0,0,0,0,0,0.99"; groupmark=',').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "1 0 0 0 0 0 0 0 0.99"; groupmark=' ').val == 100_000_000.99
     @test Parsers.xparse(Float64, "100000000.99"; groupmark=',').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "100000000.99,aaa"; groupmark=',') == Parsers.Result{Float64}(Int16(9), 13, 1.0000000099e8)
+    @test Parsers.xparse(Float64, "\"100,000,000.99\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(13), 17, 1.0000000099e8)
+    @test Parsers.xparse(Float64, "100,000,000.99,100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(9), 15, 1.0000000099e8)
+    @test Parsers.xparse(Float64, "\"100,000,000\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(13), 14, 1.0e8)
 
     @test Parsers.xparse(Float32, "100,000,000.99"; groupmark=',').val ≈ 100_000_000.99
+    @test Parsers.xparse(Float32, "100,000,000"; groupmark=',').val ≈ 100_000_000.0
     @test Parsers.xparse(Float32, "1,0,0,0,0,0,0,0,0.99"; groupmark=',').val ≈ 100_000_000.99
+    @test Parsers.xparse(Float32, "1 0 0 0 0 0 0 0 0.99"; groupmark=' ').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "100000000.99"; groupmark=',').val ≈ 100_000_000.99
+    res = Parsers.xparse(Float32, "100000000.99,aaa"; groupmark=',')
+    @test res.code == Int16(9)
+    @test res.tlen == 13
+    @test res.val ≈ 100_000_000.99
 
     @test Parsers.xparse(Float64, "100,000,00099e-2"; groupmark=',').val == 100_000_000.99
     @test Parsers.xparse(Float64, "1,0,0,0,0,0,0,0,099e-2"; groupmark=',').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "1 0 0 0 0 0 0 0 099e-2"; groupmark=' ').val == 100_000_000.99
     @test Parsers.xparse(Float64, "10000000099e-2"; groupmark=',').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "10000000099e-2,aaa"; groupmark=',') == Parsers.Result{Float64}(Int16(9), 15, 1.0000000099e8)
+    @test Parsers.xparse(Float64, "\"10000000099e-2\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(13), 17, 1.0000000099e8)
+    @test Parsers.xparse(Float64, "10000000099e-2,100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(9), 15, 1.0000000099e8)
 
     @test Parsers.xparse(Float32, "100,000,00099e-2"; groupmark=',').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "1,0,0,0,0,0,0,0,099e-2"; groupmark=',').val ≈ 100_000_000.99
+    @test Parsers.xparse(Float32, "1 0 0 0 0 0 0 0 099e-2"; groupmark=' ').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "10000000099e-2"; groupmark=',').val ≈ 100_000_000.99
+    res = Parsers.xparse(Float32, "10000000099e-2,aaa"; groupmark=',')
+    @test res.code == Int16(9)
+    @test res.tlen == 15
+    @test res.val ≈ 100_000_000.99
 end
 
 # https://github.com/JuliaData/CSV.jl/issues/916

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -366,6 +366,24 @@ end
 # discovered from JSON tests
 @test Parsers.tryparse(Float64, "0e+") === nothing
 
+@testset "groupmark" begin
+    @test Parsers.xparse(Float64, "100,000,000.99"; groupmark=',').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "1,0,0,0,0,0,0,0,0.99"; groupmark=',').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "100000000.99"; groupmark=',').val == 100_000_000.99
+
+    @test Parsers.xparse(Float32, "100,000,000.99"; groupmark=',').val ≈ 100_000_000.99
+    @test Parsers.xparse(Float32, "1,0,0,0,0,0,0,0,0.99"; groupmark=',').val ≈ 100_000_000.99
+    @test Parsers.xparse(Float32, "100000000.99"; groupmark=',').val ≈ 100_000_000.99
+
+    @test Parsers.xparse(Float64, "100,000,00099e-2"; groupmark=',').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "1,0,0,0,0,0,0,0,099e-2"; groupmark=',').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "10000000099e-2"; groupmark=',').val == 100_000_000.99
+
+    @test Parsers.xparse(Float32, "100,000,00099e-2"; groupmark=',').val ≈ 100_000_000.99
+    @test Parsers.xparse(Float32, "1,0,0,0,0,0,0,0,099e-2"; groupmark=',').val ≈ 100_000_000.99
+    @test Parsers.xparse(Float32, "10000000099e-2"; groupmark=',').val ≈ 100_000_000.99
+end
+
 # https://github.com/JuliaData/CSV.jl/issues/916
 @test  Parsers.parse(Float64, "0.44311945001372019574271437679879349172") === 0.4431194500137202
 @test Parsers.parse(BigFloat, "0.44311945001372019574271437679879349172") == BigFloat("0.44311945001372019574271437679879349172")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -293,12 +293,25 @@ end # @testset "Core Parsers.xparse"
     @test Parsers.xparse(Int64, "100000000"; groupmark=',').val == 100_000_000
     @test Parsers.xparse(Int64, "9223372036854775807"; groupmark=',').val == 9223372036854775807
     @test Parsers.xparse(Int64, "9,2,2,3,3,7,2,0,3,6,8,5,4,7,7,5,8,0,7"; groupmark=',').val == 9223372036854775807
+    @test Parsers.xparse(Int64, "9 2 2 3 3 7 2 0 3 6 8 5 4 7 7 5 8 0 7"; groupmark=' ').val == 9223372036854775807
+    @test Parsers.xparse(Int64, "100,000,000,aaa"; groupmark=',') == Parsers.Result{Int64}(Int16(9), 12, 100_000_000)
+    @test Parsers.xparse(Int64, "100,000,000,aaa"; groupmark=',') == Parsers.Result{Int64}(Int16(9), 12, 100_000_000)
+    @test Parsers.xparse(Int64, "\"100,000,000\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Int64}(Int16(13), 14, 100_000_000)
 
     @test Parsers.xparse(Int32, "100,000,000"; groupmark=',').val == 100_000_000
     @test Parsers.xparse(Int32, "1,0,0,0,0,0,0,0,0"; groupmark=',').val == 100_000_000
     @test Parsers.xparse(Int32, "100000000"; groupmark=',').val == 100_000_000
-    @test Parsers.xparse(Int64, "2147483647"; groupmark=',').val == 2147483647
-    @test Parsers.xparse(Int64, "2,1,4,7,4,8,3,6,4,7"; groupmark=',').val == 2147483647
+    @test Parsers.xparse(Int32, "2147483647"; groupmark=',').val == 2147483647
+    @test Parsers.xparse(Int32, "2,1,4,7,4,8,3,6,4,7"; groupmark=',').val == 2147483647
+    @test Parsers.xparse(Int32, "2 1 4 7 4 8 3 6 4 7"; groupmark=' ').val == 2147483647
+    @test Parsers.xparse(Int32, "100,000,000,aaa"; groupmark=',') == Parsers.Result{Int32}(Int16(9), 12, 100_000_000)
+    @test Parsers.xparse(Int32, "\"100,000,000\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Int32}(Int16(13), 14, 100_000_000)
+
+    @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark=',', quoted=false, delim=',')
+    @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark='0')
+    @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark='9')
+    @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark='"', openquotechar='"')
+    @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark='"', closequotechar='"')
 end
 
 # test lots of ints

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -308,6 +308,7 @@ end # @testset "Core Parsers.xparse"
     @test Parsers.xparse(Int32, "\"100,000,000\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Int32}(Int16(13), 14, 100_000_000)
 
     @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark=',', quoted=false, delim=',')
+    @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark=',', decimal=',')
     @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark='0')
     @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark='9')
     @test_throws ArgumentError Parsers.xparse(Int64, "42"; groupmark='"', openquotechar='"')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,6 +287,20 @@ end # @testset "Core Parsers.xparse"
 
 @testset "ints" begin
 
+@testset "groupmark" begin
+    @test Parsers.xparse(Int64, "100,000,000"; groupmark=',').val == 100_000_000
+    @test Parsers.xparse(Int64, "1,0,0,0,0,0,0,0,0"; groupmark=',').val == 100_000_000
+    @test Parsers.xparse(Int64, "100000000"; groupmark=',').val == 100_000_000
+    @test Parsers.xparse(Int64, "9223372036854775807"; groupmark=',').val == 9223372036854775807
+    @test Parsers.xparse(Int64, "9,2,2,3,3,7,2,0,3,6,8,5,4,7,7,5,8,0,7"; groupmark=',').val == 9223372036854775807
+
+    @test Parsers.xparse(Int32, "100,000,000"; groupmark=',').val == 100_000_000
+    @test Parsers.xparse(Int32, "1,0,0,0,0,0,0,0,0"; groupmark=',').val == 100_000_000
+    @test Parsers.xparse(Int32, "100000000"; groupmark=',').val == 100_000_000
+    @test Parsers.xparse(Int64, "2147483647"; groupmark=',').val == 2147483647
+    @test Parsers.xparse(Int64, "2,1,4,7,4,8,3,6,4,7"; groupmark=',').val == 2147483647
+end
+
 # test lots of ints
 @time for i in typemin(Int64):100_000_000_000_000:typemax(Int64)
     str = string(i)


### PR DESCRIPTION
Inspired by the `grouping_mark` option from the R package `readr`, this allows skipping certain characters used to format numbers. I avoided the term `thousand_separators` as different locals use these marks differently (e.g., [indian numbering system](https://en.wikipedia.org/wiki/Indian_numbering_system) would format the number 5000000 as `50,00,000`).