### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -196,7 +196,7 @@ function peekbyte end
 incr!(io::IO) = readbyte(io)
 readbyte(from::IO) = Base.read(from, UInt8)
 peekbyte(from::IO) = UInt8(Base.peek(from))
-function dpeekbyte(s::IO) where T
+function dpeekbyte(s::IO)
     mark(s)
     b = EOF_BYTE
     nb = EOF_BYTE


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.

FTR, there's a relevant function in Test in stdlib for checking this stuff:
https://docs.julialang.org/en/v1/stdlib/Test/#Test.detect_unbound_args