### PR TITLE
Use Aqua and JET in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,9 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Aqua", "Test", "JET"]

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -242,6 +242,8 @@ function xparse(::Type{T}, source, pos, len, options, ::Type{S}=T) where {T, S}
     end
 end
 
+xparse(::Type{Char}, buf::AbstractString, pos, len, options, ::Type{S}=Char) where {S} =
+    xparse(Char, codeunits(buf), pos, len, options, S)
 function xparse(::Type{Char}, source, pos, len, options, ::Type{S}=Char) where {S}
     res = xparse(String, source, pos, len, options)
     code = res.code
@@ -253,8 +255,10 @@ function xparse(::Type{Char}, source, pos, len, options, ::Type{S}=Char) where {
     end
 end
 
+xparse(::Type{Symbol}, buf::AbstractString, pos, len, options, ::Type{S}=Symbol) where {S} =
+    xparse(Symbol, codeunits(buf), pos, len, options, S)
 function xparse(::Type{Symbol}, source, pos, len, options, ::Type{S}=Symbol) where {S}
-    res = xparse(String, source, pos, len, options)
+    res = xparse(String, source, pos, len, options, PosLen)
     code = res.code
     poslen = res.val
     if !Parsers.invalid(code) && !Parsers.sentinel(code)

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -206,7 +206,7 @@ end
             end
             if has_groupmark
                 b, nb = dpeekbyte(source, pos) .- UInt8('0')
-                if options.groupmark - UInt8('0') == b && nb <= 0x09
+                if (options.groupmark)::UInt8 - UInt8('0') == b && nb <= 0x09
                     incr!(source)
                     pos += 1
                     b = nb

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -35,7 +35,7 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
         end
         if has_groupmark
             b, nb = dpeekbyte(source, pos) .- UInt8('0')
-            if options.groupmark - UInt8('0') == b && nb <= 0x09
+            if (options.groupmark)::UInt8 - UInt8('0') == b && nb <= 0x09
                 incr!(source)
                 pos += 1
                 b = nb
@@ -78,7 +78,7 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
         end
         if has_groupmark
             b, nb = dpeekbyte(source, pos) .- UInt8('0')
-            if options.groupmark - UInt8('0') == b && nb <= 0x09
+            if (options.groupmark)::UInt8 - UInt8('0') == b && nb <= 0x09
                 incr!(source)
                 pos += 1
                 b = nb

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -1,4 +1,6 @@
 # this is mostly copy-pasta from Parsers.jl main xparse function
+xparse(::Type{T}, buf::AbstractString, pos, len, options, ::Type{S}=PosLen) where {T <: AbstractString, S} =
+    xparse(String, codeunits(buf), pos, len, options, S)
 function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, options, ::Type{S}=PosLen) where {T <: AbstractString, S}
     startpos = vstartpos = vpos = lastnonwhitespacepos = pos
     sentstart = sentinelpos = 0


### PR DESCRIPTION
Using Aqua, this PR automates checking for method ambiguities, unbound type parameters, undefined exports, and compat bounds being set.

Using JET to make sure `xparse` doesn't have dynamic dispatch or boxed variables in closures. There seem to be code paths leading to dynamic dispatch when parsing `Date` and `Time` types.