### PR TITLE
Revert "Use Aqua and JET in tests (#130)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 julia = "1"
 
 [extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "JET"]
+test = ["Test"]

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -242,8 +242,6 @@ function xparse(::Type{T}, source, pos, len, options, ::Type{S}=T) where {T, S}
     end
 end
 
-xparse(::Type{Char}, buf::AbstractString, pos, len, options, ::Type{S}=Char) where {S} =
-    xparse(Char, codeunits(buf), pos, len, options, S)
 function xparse(::Type{Char}, source, pos, len, options, ::Type{S}=Char) where {S}
     res = xparse(String, source, pos, len, options)
     code = res.code
@@ -255,10 +253,8 @@ function xparse(::Type{Char}, source, pos, len, options, ::Type{S}=Char) where {
     end
 end
 
-xparse(::Type{Symbol}, buf::AbstractString, pos, len, options, ::Type{S}=Symbol) where {S} =
-    xparse(Symbol, codeunits(buf), pos, len, options, S)
 function xparse(::Type{Symbol}, source, pos, len, options, ::Type{S}=Symbol) where {S}
-    res = xparse(String, source, pos, len, options, PosLen)
+    res = xparse(String, source, pos, len, options)
     code = res.code
     poslen = res.val
     if !Parsers.invalid(code) && !Parsers.sentinel(code)

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -206,7 +206,7 @@ end
             end
             if has_groupmark
                 b, nb = dpeekbyte(source, pos) .- UInt8('0')
-                if (options.groupmark)::UInt8 - UInt8('0') == b && nb <= 0x09
+                if options.groupmark - UInt8('0') == b && nb <= 0x09
                     incr!(source)
                     pos += 1
                     b = nb

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -35,7 +35,7 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
         end
         if has_groupmark
             b, nb = dpeekbyte(source, pos) .- UInt8('0')
-            if (options.groupmark)::UInt8 - UInt8('0') == b && nb <= 0x09
+            if options.groupmark - UInt8('0') == b && nb <= 0x09
                 incr!(source)
                 pos += 1
                 b = nb
@@ -78,7 +78,7 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
         end
         if has_groupmark
             b, nb = dpeekbyte(source, pos) .- UInt8('0')
-            if (options.groupmark)::UInt8 - UInt8('0') == b && nb <= 0x09
+            if options.groupmark - UInt8('0') == b && nb <= 0x09
                 incr!(source)
                 pos += 1
                 b = nb

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -1,6 +1,4 @@
 # this is mostly copy-pasta from Parsers.jl main xparse function
-xparse(::Type{T}, buf::AbstractString, pos, len, options, ::Type{S}=PosLen) where {T <: AbstractString, S} =
-    xparse(String, codeunits(buf), pos, len, options, S)
 function xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, options, ::Type{S}=PosLen) where {T <: AbstractString, S}
     startpos = vstartpos = vpos = lastnonwhitespacepos = pos
     sentstart = sentinelpos = 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Parsers, Test, Dates
 
 import Parsers: INVALID, OK, SENTINEL, QUOTED, DELIMITED, NEWLINE, EOF, INVALID_QUOTED_FIELD, INVALID_DELIMITER, OVERFLOW, ESCAPED_STRING
-import Aqua
+
 struct CustomType
     x::String
 end
@@ -600,36 +600,5 @@ end # @testset "misc"
 include("floats.jl")
 include("dates.jl")
 include("ryu.jl")
-
-
-@testset "Aqua.jl" begin
-    Aqua.test_all(Parsers)
-end
-
-@static if Base.VERSION >= v"1.7"
-    import JET
-    @testset "JET.jl" begin
-        @testset "Optimization" begin
-            for S in (String, Vector{UInt8}, IOBuffer)
-                for T in (String, Symbol, Char, Int64, Int32, UInt64, UInt32, Float64, Float32, Bool)
-                    JET.test_opt(Parsers.xparse, Tuple{Type{T}, S, Int, Int, Parsers.Options, Type{T === String ? PosLen : T}})
-                end
-            end
-
-            JET.test_opt(Parsers.xparse, Tuple{Type{Date}, String, Int, Int, Parsers.Options, Type{Date}})
-            JET.test_opt(Parsers.xparse, Tuple{Type{Time}, String, Int, Int, Parsers.Options, Type{Time}})
-            for S in (Vector{UInt8}, IOBuffer)
-                for T in (Dates.Date, Dates.Time)
-                    JET.test_opt(Parsers.xparse, Tuple{Type{T}, S, Int, Int, Parsers.Options, Type{T}}, broken=true)
-                end
-            end
-        end
-        @testset "Typos" begin
-            res = JET.report_package(Parsers, mode=:typo, toplevel_logger=nothing);
-            @test isempty(res.res.toplevel_error_reports)
-            !isempty(res.res.toplevel_error_reports) && display(res)
-        end
-    end
-end
 
 end # @testset "Parsers"


### PR DESCRIPTION
This reverts commit 6297d57c21b882ce39709da1cef8de07559eb519.

Fastest fix for #133 if we then immediately release v2.4.2 

I'm sure we can then re-introduce this in a non-breaking way :)