### PR TITLE
Treat empty quoted field as not empty sentinel for Strings

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -34,7 +34,7 @@ function emptysentinel(checksent::Bool)
         function checkemptysentinel(::Type{T}, source, pos, len, b, code, pl) where {T}
             Base.@_inline_meta
             pos, code, pl, x = parser(T, source, pos, len, b, code, pl)
-            if checksent && pl.len == 0
+            if checksent && pl.len == 0 && (!isgreedy(T) || !quoted(code))
                 code &= ~(OK | INVALID)
                 code |= SENTINEL
                 pl = withmissing(pl)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -542,7 +542,7 @@ res = Parsers.xparse(Float64, "\"\"", 1, 2)
 @test Parsers.sentinel(res.code)
 
 res = Parsers.xparse(String, "\"\"", 1, 2)
-@test Parsers.sentinel(res.code)
+@test !Parsers.sentinel(res.code)
 
 # #38
 @test Parsers.parse(Date, "25JUL1985", Parsers.Options(dateformat="dduuuyyyy")) == Date(1985, 7, 25)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -541,6 +541,7 @@ showerror(io, e2)
 res = Parsers.xparse(Float64, "\"\"", 1, 2)
 @test Parsers.sentinel(res.code)
 
+# #138
 res = Parsers.xparse(String, "\"\"", 1, 2)
 @test !Parsers.sentinel(res.code)
 


### PR DESCRIPTION
Implements https://github.com/JuliaData/Parsers.jl/issues/138.

The biggest question I have is whether we should view this as a bugfix or a breaking change in behavior. I think it's arguable either way.

As a note, this doesn't break anything in current CSV.jl code, which is maybe a signal that this change in behavior isn't super common or makes that much of a difference?

cc: @nickrobinson251, @Drvi