### PR TITLE
Support open and close quotes being `String`

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -203,13 +203,13 @@ function Options(
     if sentinel isa Vector{String}
         for sent in sentinel
             if stripwhitespace && (_contains(sent, " ") || _contains(sent, "\t"))
-                throw(ArgumentError("sentinel value isn't allowed to start with ' ' or '\t' characters if `stripwhitespace=true`"))
+                throw(ArgumentError("sentinel value isn't allowed to contain ' ' or '\t' characters if `stripwhitespace=true`"))
             end
             if quoted && (_contains(sent, openquotechar) || _contains(sent, closequotechar) || _contains(sent, escapechar))
-                throw(ArgumentError("sentinel value isn't allowed to start with openquotechar, closequotechar, or escapechar characters"))
+                throw(ArgumentError("sentinel value isn't allowed to contain openquotechar, closequotechar, or escapechar characters"))
             end
             if _contains(sent, delim)
-                throw(ArgumentError("sentinel value isn't allowed to start with a delimiter character"))
+                throw(ArgumentError("sentinel value isn't allowed to contain a delimiter character"))
             end
         end
     end

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -202,14 +202,14 @@ function Options(
     end
     if sentinel isa Vector{String}
         for sent in sentinel
-            if stripwhitespace && (_startswith(sent, " ") || _startswith(sent, "\t"))
+            if stripwhitespace && (_contains(sent, " ") || _contains(sent, "\t"))
                 throw(ArgumentError("sentinel value isn't allowed to start with ' ' or '\t' characters if `stripwhitespace=true`"))
             end
-            if quoted && (_startswith(sent, openquotechar) || _startswith(sent, closequotechar))
+            if quoted && (_contains(sent, openquotechar) || _contains(sent, closequotechar) || _contains(sent, escapechar))
                 throw(ArgumentError("sentinel value isn't allowed to start with openquotechar, closequotechar, or escapechar characters"))
             end
-            if _startswith(sent, delim)
-                throw(ArgumentError("sentinel value isn't allowed to start with a delimiter $(isa(delim, String) ? "string" : "character")"))
+            if _contains(sent, delim)
+                throw(ArgumentError("sentinel value isn't allowed to start with a delimiter character"))
             end
         end
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -132,6 +132,9 @@ _contains(a::Char, char::Char) = a == char
 _contains(a::String, char::Char) = length(a) == 1 && @inbounds(a[1]) == char
 _contains(a::RegexAndMatchData, char::Char) = contains(a.re.pattern, char)
 
+_contains(a, b::UInt8) = _contains(a, Char(b))
+_contains(a, b) = _contains(a, string(b))
+_contains(a, b::Nothing) = false
 function Base.isempty(x::Token)
     t = x.token
     return t isa String && isempty(t)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -121,20 +121,26 @@ end
 ==(a::Token, b::UInt8) = a.token isa UInt8 && a.token == b
 ==(a::UInt8, b::Token) = (b == a)
 
+# methods for `_contains(::Token, ::String)`:
 _contains(a::Token, str::String) = _contains(a.token, str)
 _contains(a::UInt8, str::String) = a == UInt8(str[1])
 _contains(a::Char, str::String) = a == str[1]
-_contains(a::String, str::String) = contains(a, str)
 _contains(a::RegexAndMatchData, str::String) = contains(a.re.pattern, str)
 _contains(a::Token, char::Char) = _contains(a.token, char)
 _contains(a::UInt8, char::Char) = ncodeunits(char) == 1 && (Base.zext_int(UInt32, a) << 24) == Base.bitcast(UInt32, char)
 _contains(a::Char, char::Char) = a == char
-_contains(a::String, char::Char) = length(a) == 1 && @inbounds(a[1]) == char
 _contains(a::RegexAndMatchData, char::Char) = contains(a.re.pattern, char)
 
 _contains(a, b::UInt8) = _contains(a, Char(b))
 _contains(a, b) = _contains(a, string(b))
 _contains(a, b::Nothing) = false
+_contains(a::String, str::String) = contains(a, str)
+# methods for `_contains(::String, ::MaybeToken)`:
+_contains(a::String, b::UInt8) = _contains(a, Char(b))
+_contains(a::String, b::Char) = _contains(a, string(b))
+_contains(a::String, b::Regex) = contains(a, b.pattern)
+_contains(a::String, b::Nothing) = false
+
 function Base.isempty(x::Token)
     t = x.token
     return t isa String && isempty(t)


### PR DESCRIPTION
- adds the tests from 117 (#117) now that 127 is merged (#127) and we want to support `String` quotes (i.e. supersedes 117)
- ~`src/` changes here probably need a bit of tidy up, i did the minimal thing to get tests passing, but i think the `_contains` function could do with a clean-up~
- we should probably go through other things that are now genralised to be `MaybeToken` and check all cases are working as expected... in some follow-up PRs