### PR TITLE
Remove OK code when sentinel is matched

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -241,10 +241,11 @@ function sentinel(chcksentinel, sentinel)
             # @show match, sentinelpos, pos, pl
             if match && sentinelpos > (pl.pos + pl.len - 1)
                 # if we matched a sentinel value that was as long or longer than our type value
+                code &= ~OK
                 if isgreedy(T)
                     pl = withlen(pl, sentinelpos - pl.pos)
                 else
-                    code &= ~(OK | INVALID | EOF | OVERFLOW)
+                    code &= ~(INVALID | EOF | OVERFLOW)
                     pos = sentinelpos
                     fastseek!(source, pos - 1)
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,6 +260,10 @@ res = Parsers.xparse(Int64, "1\n"; sentinel=["", " ", "  "])
 @test res.tlen == 2
 @test res.code == (OK | EOF | NEWLINE)
 
+# #140, #142 
+res = Parsers.xparse(String, "NA"; sentinel=["NA"])
+@test res.code == (SENTINEL | EOF)
+
 # stripwhitespace
 res = Parsers.xparse(String, "{hey there}"; openquotechar='{', closequotechar='}', stripwhitespace=true)
 @test res.val.pos == 2 && res.val.len == 9


### PR DESCRIPTION
This broke the InlineStrings tests. Regardless of greedy or non-greedy, we want to remove the OK code, since that should be mutually exclusive with the SENTINEL code.