### PR TITLE
Bring performance back to pre-refactor levels

### DIFF
--- a/benchmarks/parsers.jl
+++ b/benchmarks/parsers.jl
@@ -1,19 +1,22 @@
 using BenchmarkTools, Parsers, Dates
 
-# parse
-@benchmark Parsers.parse(String, "\"-86706967560385154\",")
-@benchmark Parsers.parse(String, "-86706967560385154")
-
 # tryparse
 @benchmark Parsers.parse(Int64, "-86706967560385154")
 @benchmark Parsers.tryparse(Int64, "-86706967560385154")
 
 # xparse
 @benchmark Parsers.xparse(Int64, "\"-86706967560385154\",", 1, 21)
-@benchmark Parsers.xparse(Int64, "-86706967560385154", 1, 18)
+@benchmark Parsers.xparse(Int64, "-86706967560385154", 1, 18, Parsers.XOPTIONS, Int64)
 
+const ff = Parsers.Result(Parsers.emptysentinel(options)(Parsers.delimiter(options)(Parsers.whitespace(options)(
+    Parsers.quoted(options)(Parsers.whitespace(options)(Parsers.sentinel(options)(Parsers.typeparser(options)
+)))))))
+const buf = Vector{UInt8}("\"-86706967560385154\",")
+@benchmark ff(String, buf, 1, 21, Parsers.PosLen)
+
+# String
 @benchmark Parsers.xparse(String, "\"-86706967560385154\",", 1, 21)
-@benchmark Parsers.xparse(String, "-86706967560385154", 1, 18)
+@benchmark Parsers.xparse(String, "-86706967560385154", 1, 18, Parsers.XOPTIONS, Parsers.PosLen)
 
 # Int
 @benchmark Parsers.parse(Int64, "10")
@@ -34,6 +37,11 @@ using BenchmarkTools, Parsers, Dates
 @benchmark Base.parse(Float64, "2.2250738585072011e-308")
 
 # Date
+#TODO
+const ffff = Parsers.Result(Parsers.typeparser(Parsers.OPTIONS))
+const src = Vector{UInt8}("2019-01-01")
+@benchmark ffff(Date, src, 1, 10, Date)
+@benchmark Parsers._xparse2(Date, src, 1, 10, Parsers.OPTIONS, Date)
 @benchmark Parsers.parse(Date, "2019-01-01")
 @benchmark Base.parse(Date, "2019-01-01")
 

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -305,7 +305,7 @@ const SourceType = Union{AbstractVector{UInt8}, AbstractString, IO}
 xparse(::Type{T}, source::SourceType; pos::Integer=1, len::Integer=source isa IO ? 0 : sizeof(source), kw...) where {T} =
     xparse(T, source, pos, len, Options(; kw...))
 
-_xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, options::Options=XOPTIONS, ::Type{S}=(T <: AbstractString) ? PosLen : T) where {T <: SupportedTypes, S} =
+@inline _xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, options::Options=XOPTIONS, ::Type{S}=(T <: AbstractString) ? PosLen : T) where {T <: SupportedTypes, S} =
     Result(emptysentinel(options)(delimiter(options)(whitespace(options)(
         quoted(options)(whitespace(options)(sentinel(options)(typeparser(options)
     )))))))(T, source, pos, len, S)

--- a/src/components.jl
+++ b/src/components.jl
@@ -380,7 +380,7 @@ function typeparser(opts::Options)
 end
 
 # backwards compat
-function typeparser(T, source, pos, len, b, code, opts::Options)
+@inline function typeparser(T, source, pos, len, b, code, opts::Options)
     pos, code, pl, x = typeparser(T, source, pos, len, b, code, poslen(pos, 0), opts)
     return x, code, pos
 end

--- a/src/components.jl
+++ b/src/components.jl
@@ -107,7 +107,7 @@ function whitespace(spacedelim, tabdelim, stripquoted, stripwh)
     end
 end
 
-function findendquoted(::Type{T}, source, pos, len, b, code, pl, isquoted, cq, e, stripquoted) where {T}
+@inline function findendquoted(::Type{T}, source, pos, len, b, code, pl, isquoted, cq, e, stripquoted) where {T}
     # for quoted fields, find the closing quote character
     # we should be positioned at the correct place to find the closing quote character if everything is as it should be
     # if we don't find the quote character immediately, something's wrong, so mark INVALID
@@ -260,7 +260,7 @@ function sentinel(chcksentinel, sentinel)
     end
 end
 
-function finddelimiter(::Type{T}, source, pos, len, b, code, pl, delim, ignorerepeated, cmt, ignoreemptylines, stripwhitespace) where {T}
+@inline function finddelimiter(::Type{T}, source, pos, len, b, code, pl, delim, ignorerepeated, cmt, ignoreemptylines, stripwhitespace) where {T}
     # now we check for a delimiter; if we don't find it, keep parsing until we do
     # for greedy strings, we need to keep track of the last non-whitespace character
     # if we're stripping whitespace, but note we've already skipped leading whitespace

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -339,11 +339,7 @@ end
     year = month = day = Int64(1)
     hour = minute = second = millisecond = Int64(0)
     tz = ""
-    @static if VERSION >= v"1.3-DEV"
-        ampm = Dates.TWENTYFOURHOUR
-    else
-        ampm = 0
-    end
+    ampm = Dates.TWENTYFOURHOUR
     extras = nothing
     for tok in tokens
         # @show pos, Char(b), code, typeof(tok)

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -2,13 +2,13 @@ isgreedy(::Type{T}) where {T <: AbstractString} = true
 isgreedy(::Type{Symbol}) = true
 isgreedy(T) = false
 
-function typeparser(::Type{T}, source, pos, len, b, code, pl, opts) where {T <: AbstractString}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, pl, opts) where {T <: AbstractString}
     if quoted(code)
         code |= OK
-        return findendquoted(T, source, pos, len, b, code, pl, true, opts.cq, opts.e, opts.flags.stripquoted)
+        return @inline findendquoted(T, source, pos, len, b, code, pl, true, opts.cq, opts.e, opts.flags.stripquoted)
     elseif opts.flags.checkdelim
         code |= OK
-        return finddelimiter(T, source, pos, len, b, code, pl, opts.delim, opts.flags.ignorerepeated, opts.cmt, opts.flags.ignoreemptylines, opts.flags.stripwhitespace)
+        return @inline finddelimiter(T, source, pos, len, b, code, pl, opts.delim, opts.flags.ignorerepeated, opts.cmt, opts.flags.ignoreemptylines, opts.flags.stripwhitespace)
     else
         code |= OK
         return findeof(source, pos, len, b, code, pl, opts)

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -5,10 +5,10 @@ isgreedy(T) = false
 @inline function typeparser(::Type{T}, source, pos, len, b, code, pl, opts) where {T <: AbstractString}
     if quoted(code)
         code |= OK
-        return @inline findendquoted(T, source, pos, len, b, code, pl, true, opts.cq, opts.e, opts.flags.stripquoted)
+        return findendquoted(T, source, pos, len, b, code, pl, true, opts.cq, opts.e, opts.flags.stripquoted)
     elseif opts.flags.checkdelim
         code |= OK
-        return @inline finddelimiter(T, source, pos, len, b, code, pl, opts.delim, opts.flags.ignorerepeated, opts.cmt, opts.flags.ignoreemptylines, opts.flags.stripwhitespace)
+        return finddelimiter(T, source, pos, len, b, code, pl, opts.delim, opts.flags.ignorerepeated, opts.cmt, opts.flags.ignoreemptylines, opts.flags.stripwhitespace)
     else
         code |= OK
         return findeof(source, pos, len, b, code, pl, opts)


### PR DESCRIPTION
Mainly just sprinkling around some `@inline` calls. In the `benchmarks/parsers.jl` file, I have some common types where I'm checking performance of Parsers.jl vs. Base and I also checked the current Parsers.jl release vs. #main branch. Performance looks very very close, with only Strings being about 5% slower. I ran out of gas looking to why that may be, but I think that's within the range of acceptability IMO.