### PR TITLE
Fix equality definition between byte and Token

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Parsers"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -117,6 +117,7 @@ function ==(a::Token, b::Token)
     end
 end
 ==(a::Token, b::UInt8) = a.token isa UInt8 && a.token == b
+==(a::UInt8, b::Token) = (b == a)
 _contains(a::Token, str::String) = _contains(a.token, str)
 _contains(a::UInt8, str::String) = a == UInt8(str[1])
 _contains(a::Char, str::String) = a == str[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,7 +260,7 @@ res = Parsers.xparse(Int64, "1\n"; sentinel=["", " ", "  "])
 @test res.tlen == 2
 @test res.code == (OK | EOF | NEWLINE)
 
-# #140, #142 
+# #140, #142
 res = Parsers.xparse(String, "NA"; sentinel=["NA"])
 @test res.code == (SENTINEL | EOF)
 
@@ -645,6 +645,12 @@ res = Parsers.xparse(String, source, 1 + res.tlen, 0, opt)
 # checkdelim!
 buf = UInt8[0x20, 0x20, 0x41, 0x20, 0x20, 0x42, 0x0a, 0x20, 0x20, 0x31, 0x20, 0x20, 0x32, 0x0a, 0x20, 0x20, 0x31, 0x31, 0x20, 0x32, 0x32]
 @test Parsers.checkdelim!(buf, 1, 21, Parsers.Options(delim=' ', ignorerepeated=true)) == 3
+
+# #150
+@test 0x22 == Parsers.Token(0x22)
+@test 0x22 != Parsers.Token(0x00)
+@test Parsers.Token(0x22) == 0x22
+@test Parsers.Token(0x22) != 0x00
 
 end # @testset "misc"
 


### PR DESCRIPTION
- close #150 
  - confirmed that `OpenML.load(42638)` works when using this branch of Parsers.jl