### PR TITLE
Extend Options' inputs validation

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -506,6 +506,11 @@ pos += tlen
 @test_throws ArgumentError Parsers.Options(sentinel=["\""])
 @test_throws ArgumentError Parsers.Options(sentinel=[","], delim=',')
 @test_throws ArgumentError Parsers.Options(sentinel=[","], delim=",")
+@test_throws ArgumentError Parsers.Options(delim=r"\"")
+@test_throws ArgumentError Parsers.Options(openquotechar="aaa", delim=r"a+")
+@test_throws ArgumentError Parsers.Options(openquotechar=r"a+", delim="aaa")
+@test_throws ArgumentError Parsers.Options(escapechar=UInt8('a'), delim="a")
+@test_throws ArgumentError Parsers.Options(escapechar='a', delim=r"a")
 
 @test Parsers.checkdelim!(UInt8[], 1, 0, Parsers.OPTIONS) == 1
 @test Parsers.checkdelim!(codeunits(","), 1, 1, Parsers.XOPTIONS) == 2


### PR DESCRIPTION
This generalizes the compatibility checks between `escapechar`, `openquotechar`, `closequotechar`, `delim` and the sentinel values. We still fail to correctly validate pairs of regular expressions as those would have to be somehow reduced to their minimal canonical form (I'm sure there is a fancy CS name for this).