### PR TITLE
Ensure Char doesn't match provided delim before marking OK

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -69,6 +69,7 @@ function typeparser(::Type{Char}, source, pos, len, b, code, pl, opts)
         code |= INVALID
         code &= ~EOF
         pos = startpos
+        fastseek!(source, startpos)
     else
         code |= OK
     end

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -36,6 +36,10 @@ function typeparser(::Type{Char}, source, pos, len, b, code, pl, opts)
     startpos = pos
     l = 8 * (4 - leading_ones(b))
     c = UInt32(b) << 24
+    if eof(source, pos, len)
+        code |= INVALID | EOF
+        @goto done
+    end
     s = 16
     while true
         pos += 1
@@ -63,6 +67,7 @@ function typeparser(::Type{Char}, source, pos, len, b, code, pl, opts)
         code |= INVALID
     elseif opts.flags.checkdelim && _contains(opts.delim, ch)
         code |= INVALID
+        code &= ~EOF
         pos = startpos
     else
         code |= OK

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -118,11 +118,18 @@ function ==(a::Token, b::Token)
 end
 ==(a::Token, b::UInt8) = a.token isa UInt8 && a.token == b
 ==(a::UInt8, b::Token) = (b == a)
+
 _contains(a::Token, str::String) = _contains(a.token, str)
 _contains(a::UInt8, str::String) = a == UInt8(str[1])
 _contains(a::Char, str::String) = a == str[1]
 _contains(a::String, str::String) = contains(a, str)
 _contains(a::RegexAndMatchData, str::String) = contains(a.re.pattern, str)
+_contains(a::Token, char::Char) = _contains(a.token, char)
+_contains(a::UInt8, char::Char) = ncodeunits(char) == 1 && (Base.zext_int(UInt32, a) << 24) == Base.bitcast(UInt32, char)
+_contains(a::Char, char::Char) = a == char
+_contains(a::String, char::Char) = length(a) == 1 && @inbounds(a[1]) == char
+_contains(a::RegexAndMatchData, char::Char) = contains(a.re.pattern, char)
+
 function Base.isempty(x::Token)
     t = x.token
     return t isa String && isempty(t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -656,6 +656,9 @@ buf = UInt8[0x20, 0x20, 0x41, 0x20, 0x20, 0x42, 0x0a, 0x20, 0x20, 0x31, 0x20, 0x
 res = Parsers.xparse(Char, ",,345", 1, 5, Parsers.Options(sentinel=missing, delim=','))
 @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
 @test res.tlen == 1
+res = Parsers.xparse(Char, IOBuffer(",,345"), 1, 5, Parsers.Options(sentinel=missing, delim=','))
+@test res.code == Parsers.SENTINEL | Parsers.DELIMITED
+@test res.tlen == 1
 res = Parsers.xparse(Char, ",,", 2, 2, Parsers.Options(sentinel=missing, delim=','))
 @test !Parsers.eof(res.code)
 res = Parsers.xparse(Char, ",,", 3, 2, Parsers.Options(sentinel=missing, delim=','))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -676,28 +676,30 @@ include("dates.jl")
     Aqua.test_all(Parsers)
 end
 
-@static if Base.VERSION >= v"1.7"
-    import JET
-    @testset "JET.jl" begin
-        @testset "Optimization" begin
-            for S in (String, Vector{UInt8}, IOBuffer)
-                for T in (String, Symbol, Char, Int64, Int32, UInt64, UInt32, Float64, Float32, Bool)
-                    JET.test_opt(Parsers.xparse, Tuple{Type{T}, S, Int, Int, Parsers.Options, Type{T === String ? PosLen : T}})
-                end
-            end
+# TODO: Disabling JET until there is a better way to query JETs compatibility
+#        https://github.com/aviatesk/JET.jl/issues/438
+# @static if Base.VERSION >= v"1.7"
+#     import JET
+#     @testset "JET.jl" begin
+#         @testset "Optimization" begin
+#             for S in (String, Vector{UInt8}, IOBuffer)
+#                 for T in (String, Symbol, Char, Int64, Int32, UInt64, UInt32, Float64, Float32, Bool)
+#                     JET.test_opt(Parsers.xparse, Tuple{Type{T}, S, Int, Int, Parsers.Options, Type{T === String ? PosLen : T}})
+#                 end
+#             end
 
-            for S in (Vector{UInt8}, IOBuffer)
-                for T in (Dates.Date, Dates.Time)
-                    JET.test_opt(Parsers.xparse, Tuple{Type{T}, S, Int, Int, Parsers.Options, Type{T}}, broken=true)
-                end
-            end
-        end
-        @testset "Typos" begin
-            res = JET.report_package(Parsers, mode=:typo, toplevel_logger=nothing);
-            @test isempty(res.res.toplevel_error_reports)
-            !isempty(res.res.toplevel_error_reports) && display(res)
-        end
-    end
-end
+#             for S in (Vector{UInt8}, IOBuffer)
+#                 for T in (Dates.Date, Dates.Time)
+#                     JET.test_opt(Parsers.xparse, Tuple{Type{T}, S, Int, Int, Parsers.Options, Type{T}}, broken=true)
+#                 end
+#             end
+#         end
+#         @testset "Typos" begin
+#             res = JET.report_package(Parsers, mode=:typo, toplevel_logger=nothing);
+#             @test isempty(res.res.toplevel_error_reports)
+#             !isempty(res.res.toplevel_error_reports) && display(res)
+#         end
+#     end
+# end
 
 end # @testset "Parsers"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -652,6 +652,11 @@ buf = UInt8[0x20, 0x20, 0x41, 0x20, 0x20, 0x42, 0x0a, 0x20, 0x20, 0x31, 0x20, 0x
 @test Parsers.Token(0x22) == 0x22
 @test Parsers.Token(0x22) != 0x00
 
+# Char doesn't match delim
+res = Parsers.xparse(Char, ",,345", 1, 5, Parsers.Options(sentinel=missing, delim=','))
+@test res.code == Parsers.SENTINEL | Parsers.DELIMITED
+@test res.tlen == 1
+
 end # @testset "misc"
 
 include("floats.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -656,6 +656,9 @@ buf = UInt8[0x20, 0x20, 0x41, 0x20, 0x20, 0x42, 0x0a, 0x20, 0x20, 0x31, 0x20, 0x
 res = Parsers.xparse(Char, ",,345", 1, 5, Parsers.Options(sentinel=missing, delim=','))
 @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
 @test res.tlen == 1
+res = Parsers.xparse(Char, ",,", 2, 2, Parsers.Options(sentinel=missing, delim=','))
+@test !Parsers.eof(res.code)
+res = Parsers.xparse(Char, ",,", 3, 2, Parsers.Options(sentinel=missing, delim=','))
 
 end # @testset "misc"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -653,7 +653,7 @@ buf = UInt8[0x20, 0x20, 0x41, 0x20, 0x20, 0x42, 0x0a, 0x20, 0x20, 0x31, 0x20, 0x
 @test Parsers.Token(0x22) != 0x00
 
 # Char doesn't match delim
-for delim in (',', ",")
+for delim in (',', ",", r",")
     res = Parsers.xparse(Char, ",,345", 1, 5, Parsers.Options(sentinel=missing, delim=delim))
     @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
     @test res.tlen == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -660,8 +660,11 @@ res = Parsers.xparse(Char, IOBuffer(",,345"), 1, 5, Parsers.Options(sentinel=mis
 @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
 @test res.tlen == 1
 res = Parsers.xparse(Char, ",,", 2, 2, Parsers.Options(sentinel=missing, delim=','))
-@test !Parsers.eof(res.code)
+@test res.code == Parsers.SENTINEL | Parsers.DELIMITED
+@test res.tlen == 1
 res = Parsers.xparse(Char, ",,", 3, 2, Parsers.Options(sentinel=missing, delim=','))
+@test res.code == Parsers.SENTINEL | Parsers.EOF
+@test res.tlen == 0
 
 end # @testset "misc"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -653,18 +653,20 @@ buf = UInt8[0x20, 0x20, 0x41, 0x20, 0x20, 0x42, 0x0a, 0x20, 0x20, 0x31, 0x20, 0x
 @test Parsers.Token(0x22) != 0x00
 
 # Char doesn't match delim
-res = Parsers.xparse(Char, ",,345", 1, 5, Parsers.Options(sentinel=missing, delim=','))
-@test res.code == Parsers.SENTINEL | Parsers.DELIMITED
-@test res.tlen == 1
-res = Parsers.xparse(Char, IOBuffer(",,345"), 1, 5, Parsers.Options(sentinel=missing, delim=','))
-@test res.code == Parsers.SENTINEL | Parsers.DELIMITED
-@test res.tlen == 1
-res = Parsers.xparse(Char, ",,", 2, 2, Parsers.Options(sentinel=missing, delim=','))
-@test res.code == Parsers.SENTINEL | Parsers.DELIMITED
-@test res.tlen == 1
-res = Parsers.xparse(Char, ",,", 3, 2, Parsers.Options(sentinel=missing, delim=','))
-@test res.code == Parsers.SENTINEL | Parsers.EOF
-@test res.tlen == 0
+for delim in (',', ",")
+    res = Parsers.xparse(Char, ",,345", 1, 5, Parsers.Options(sentinel=missing, delim=delim))
+    @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
+    @test res.tlen == 1
+    res = Parsers.xparse(Char, IOBuffer(",,345"), 1, 5, Parsers.Options(sentinel=missing, delim=delim))
+    @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
+    @test res.tlen == 1
+    res = Parsers.xparse(Char, ",,", 2, 2, Parsers.Options(sentinel=missing, delim=delim))
+    @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
+    @test res.tlen == 1
+    res = Parsers.xparse(Char, ",,", 3, 2, Parsers.Options(sentinel=missing, delim=delim))
+    @test res.code == Parsers.SENTINEL | Parsers.EOF
+    @test res.tlen == 0
+end
 
 end # @testset "misc"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -657,9 +657,11 @@ for delim in (',', ",", r",")
     res = Parsers.xparse(Char, ",,345", 1, 5, Parsers.Options(sentinel=missing, delim=delim))
     @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
     @test res.tlen == 1
-    res = Parsers.xparse(Char, IOBuffer(",,345"), 1, 5, Parsers.Options(sentinel=missing, delim=delim))
-    @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
-    @test res.tlen == 1
+    if !isa(delim, Regex) # Regex matching not supported on IOBuffer
+        res = Parsers.xparse(Char, IOBuffer(",,345"), 1, 5, Parsers.Options(sentinel=missing, delim=delim))
+        @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
+        @test res.tlen == 1
+    end
     res = Parsers.xparse(Char, ",,", 2, 2, Parsers.Options(sentinel=missing, delim=delim))
     @test res.code == Parsers.SENTINEL | Parsers.DELIMITED
     @test res.tlen == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -676,30 +676,4 @@ include("dates.jl")
     Aqua.test_all(Parsers)
 end
 
-# TODO: Disabling JET until there is a better way to query JETs compatibility
-#        https://github.com/aviatesk/JET.jl/issues/438
-# @static if Base.VERSION >= v"1.7"
-#     import JET
-#     @testset "JET.jl" begin
-#         @testset "Optimization" begin
-#             for S in (String, Vector{UInt8}, IOBuffer)
-#                 for T in (String, Symbol, Char, Int64, Int32, UInt64, UInt32, Float64, Float32, Bool)
-#                     JET.test_opt(Parsers.xparse, Tuple{Type{T}, S, Int, Int, Parsers.Options, Type{T === String ? PosLen : T}})
-#                 end
-#             end
-
-#             for S in (Vector{UInt8}, IOBuffer)
-#                 for T in (Dates.Date, Dates.Time)
-#                     JET.test_opt(Parsers.xparse, Tuple{Type{T}, S, Int, Int, Parsers.Options, Type{T}}, broken=true)
-#                 end
-#             end
-#         end
-#         @testset "Typos" begin
-#             res = JET.report_package(Parsers, mode=:typo, toplevel_logger=nothing);
-#             @test isempty(res.res.toplevel_error_reports)
-#             !isempty(res.res.toplevel_error_reports) && display(res)
-#         end
-#     end
-# end
-
 end # @testset "Parsers"


### PR DESCRIPTION
In the switch to making Char non-greedy in the 2.5 release, I failed to account for the fact that the parsed Char may in fact be the delimiter provided, in which case we want to match the delim instead of treating it as a successfully parsed Char (Char is greedy in this way like Strings).

Luckily we can still do this pretty efficiently by checking our parsed Char against the delimiter, if there is one.