### PR TITLE
Make Flags serializable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,8 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test"]
+test = ["Aqua", "Serialization", "Test"]

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -65,6 +65,9 @@ end
 
 Base.show(io::IO, x::Flags) = print(io, "Parsers.Flags(spacedelim=", x.spacedelim, ", tabdelim=", x.tabdelim, ", stripquoted=", x.stripquoted, ", stripwhitespace=", x.stripwhitespace, ", checkquoted=", x.checkquoted, ", checksentinel=", x.checksentinel, ", checkdelim=", x.checkdelim, ", ignorerepeated=", x.ignorerepeated, ", ignoreemptylines=", x.ignoreemptylines, ")")
 
+Base.write(io::IO, flag::Flags) = write(io, reinterpret(UInt16, flag))
+Base.read(io::IO, ::Type{Flags}) = Base.bitcast(Flags, read(io, UInt16))
+
 function Base.getproperty(x::Flags, nm::Symbol)
     if nm == :spacedelim
         return Base.bitcast(UInt16, x) & SPACEDELIM != 0x00

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Parsers, Test, Dates
 
 import Parsers: INVALID, OK, SENTINEL, QUOTED, DELIMITED, NEWLINE, EOF, INVALID_QUOTED_FIELD, INVALID_DELIMITER, OVERFLOW, ESCAPED_STRING, SPECIAL_VALUE
 import Aqua
+import Serialization
 struct CustomType
     x::String
 end
@@ -717,6 +718,13 @@ end
     @test Parsers.parse(Number, "170141183460469231731687303715884105728") == 170141183460469231731687303715884105728
     # BigFloat promotion
     @test Parsers.parse(Number, "1e310") == Base.parse(BigFloat, "1e310")
+end
+
+# https://github.com/JuliaData/CSV.jl/issues/1063
+@testset "Serialization" begin
+    tempfile = tempname()
+    Serialization.serialize(tempfile, Parsers.Options())
+    @test Serialization.deserialize(tempfile).flags == Parsers.Options().flags
 end
 
 end # @testset "Parsers"


### PR DESCRIPTION
Quick fix for https://github.com/JuliaData/CSV.jl/issues/1063

This makes `Flags` serializable, which in turns allows serializing `Options` and, downstream, `CSV.File` and such.