### PR TITLE
Improve performance of Parsers.parse(Number, ...)

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -45,11 +45,6 @@ function _muladd(ten, digits::BigInt, b)
 end
 
 @enum FloatType FLOAT16 FLOAT32 FLOAT64 BIGFLOAT
-float_type(::Type{T}, FT::FloatType) where {T <: AbstractFloat} = T
-float_type(T, FT::FloatType) = FT === FLOAT16 ? Float16 :
-    FT === FLOAT32 ? Float32 :
-    FT === FLOAT64 ? Float64 :
-    BigFloat
 
 # for non SupportedFloat Reals, parse as Float64, then convert
 @inline function typeparser(::Type{T}, source, pos, len, b, code, pl, options) where {T <: Real}
@@ -217,11 +212,20 @@ end
     return pos, code, PosLen(pl.pos, pos - pl.pos), x
 end
 
-# if we need to _widen the type due to `digits` overflow, we want a non-inlined version so base case compilation doesn't get out of control
-@noinline _parsedigits(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos) where {T, IntType} =
-    parsedigits(T, source, pos, len, b, code, options, digits, neg, startpos)
+@inbounds function handlef(x, f::F) where {F}
+    if f === nothing
+        return x
+    else
+        f(x)
+        return nothing
+    end
+end
 
-@inline function parsedigits(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos) where {T, IntType}
+# if we need to _widen the type due to `digits` overflow, we want a non-inlined version so base case compilation doesn't get out of control
+@noinline _parsedigits(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, f::F) where {T, IntType, F} =
+    parsedigits(T, source, pos, len, b, code, options, digits, neg, startpos, f)
+
+@inline function parsedigits(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, f::F=nothing) where {T, IntType, F}
     x = zero(T)
     ndigits = 0
     has_groupmark = options.groupmark !== nothing
@@ -235,7 +239,7 @@ end
             ndigits += 1
             if eof(source, pos, len)
                 # input is integer, like "1"
-                x = ifelse(neg, -T(digits), T(digits))
+                x = handlef(ifelse(neg, -T(digits), T(digits)), f)
                 code |= OK | EOF
                 @goto done
             end
@@ -252,7 +256,7 @@ end
             # if `b` isn't a digit, time to break out of digit parsing while loop
             b > 0x09 && break
             if overflows(IntType) && digits > overflowval(IntType)
-                return _parsedigits(T, source, pos, len, b + UInt8('0'), code, options, _widen(digits), neg, startpos)
+                return _parsedigits(T, source, pos, len, b + UInt8('0'), code, options, _widen(digits), neg, startpos, f)
             elseif ndigits > maxdigits(T)
                 # if input is way too big, just bail
                 fastseek!(source, startpos - 1)
@@ -269,7 +273,7 @@ end
         incr!(source)
         if eof(source, pos, len)
             # if input is "." then invalid, otherwise ok, like "1."
-            x = ifelse(neg, -T(digits), T(digits))
+            x = handlef(ifelse(neg, -T(digits), T(digits)), f)
             code |= ((startpos + 1) == pos ? INVALID : OK) | EOF
             @goto done
         end
@@ -282,7 +286,7 @@ end
                 code |= INVALID
                 @goto done
             else
-                x = ifelse(neg, -T(digits), T(digits))
+                x = handlef(ifelse(neg, -T(digits), T(digits)), f)
                 code |= OK
                 @goto done
             end
@@ -293,7 +297,7 @@ end
     # now we parse any digits following decimal point (if any); start `frac` at UInt64(0)
     # `digits` still receives any fractional digits, `frac` just keeps track of how many digits
     # were parsed to combine with any "e123" exponent numbers to determine final exponent value
-    x, code, pos = parsefrac(T, source, pos, len, b, code, options, digits, neg, startpos, UInt64(0))
+    x, code, pos = parsefrac(T, source, pos, len, b, code, options, digits, neg, startpos, UInt64(0), f)
 
 @label done
     return x, code, pos
@@ -302,10 +306,10 @@ end
 # same as above; if digits overflows, we want a non-inlined version to call with a wider type
 # note that we never expect `frac` to overflow, since it's just keep track of the # of digits
 # we parse post-decimal point
-@noinline _parsefrac(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac) where {T, IntType} =
-    parsefrac(T, source, pos, len, b, code, options, digits, neg, startpos, frac)
+@noinline _parsefrac(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac, f::F) where {T, IntType, F} =
+    parsefrac(T, source, pos, len, b, code, options, digits, neg, startpos, frac, f)
 
-@inline function parsefrac(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac) where {T, IntType}
+@inline function parsefrac(::Type{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac, f::F) where {T, IntType, F}
     x = zero(T)
     parsedanyfrac = false
     FT = FLOAT64
@@ -321,14 +325,14 @@ end
             frac += UInt64(1)
             if eof(source, pos, len)
                 # input is simple non-scientific-notation floating number, like "1.1"
-                x = scale(T, FT, digits, -signed(frac), neg)
+                x = scale(T, FT, digits, -signed(frac), neg, f)
                 code |= OK | EOF
                 @goto done
             end
             b = peekbyte(source, pos) - UInt8('0')
             b > 0x09 && break
             if overflows(IntType) && digits > overflowval(IntType)
-                return _parsefrac(T, source, pos, len, b + UInt8('0'), code, options, _widen(digits), neg, startpos, frac)
+                return _parsefrac(T, source, pos, len, b + UInt8('0'), code, options, _widen(digits), neg, startpos, frac, f)
             end
         end
         b += UInt('0')
@@ -366,13 +370,13 @@ end
 
         # at this point, we've parsed X and Y in "X.YeZ", but not Z in a scientific notation exponent number
         # we start our exponent number at UInt64(0)
-        return parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, UInt64(0), negexp, FT)
+        return parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, UInt64(0), negexp, FT, f)
     else
         # if no scientific notation, we're done, so scale digits + frac and return
         if parsedanyfrac
-            x = scale(T, FT, digits, -signed(frac), neg)
+            x = scale(T, FT, digits, -signed(frac), neg, f)
         else
-            x = ifelse(neg, -T(digits), T(digits))
+            x = handlef(ifelse(neg, -T(digits), T(digits)), f)
         end
         code |= OK
     end
@@ -383,10 +387,10 @@ end
 
 # same no-inline story, but this time for exponent number; probably even more rare to overflow the exponent number
 # compared to pre/post decimal digits, but we account for it all the same (a lot of float parsers don't account for this)
-@noinline _parseexp(::Type{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT) where {T, ExpType} =
-    parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, exp, negexp, FT)
+@noinline _parseexp(::Type{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT, f::F) where {T, ExpType, F} =
+    parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, exp, negexp, FT, f)
 
-@inline function parseexp(::Type{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT) where {T, ExpType}
+@inline function parseexp(::Type{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT, f::F) where {T, ExpType, F}
     x = zero(T)
     # note that `b` has already had `b - UInt8('0')` applied to it for parseexp
     while true
@@ -395,19 +399,19 @@ end
         incr!(source)
         if eof(source, pos, len)
             # we finished parsing input like "1.1e1"
-            x = scale(T, FT, digits, ifelse(negexp, -signed(exp), signed(exp)) - signed(frac), neg)
+            x = scale(T, FT, digits, ifelse(negexp, -signed(exp), signed(exp)) - signed(frac), neg, f)
             code |= OK | EOF
             @goto done
         end
         b = peekbyte(source, pos) - UInt8('0')
         # if we encounter a non-digit, that must mean we're done
         if b > 0x09
-            x = scale(T, FT, digits, ifelse(negexp, -signed(exp), signed(exp)) - signed(frac), neg)
+            x = scale(T, FT, digits, ifelse(negexp, -signed(exp), signed(exp)) - signed(frac), neg, f)
             code |= OK
             @goto done
         end
         if overflows(ExpType) && exp > overflowval(ExpType)
-            return _parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, _widen(exp), negexp, FT)
+            return _parseexp(T, source, pos, len, b, code, options, digits, neg, startpos, frac, _widen(exp), negexp, FT, f)
         end
     end
 @label done
@@ -437,8 +441,16 @@ pow10(::Type{BigFloat}, e) = (@inbounds v = F64_SHORT_POWERS[e+1]; return v)
 _unsigned(x::BigInt) = x
 _unsigned(x) = unsigned(x)
 
-function scale(::Type{T}, FT::FloatType, v, exp, neg) where {T}
-    return __scale(float_type(T, FT), _unsigned(v), exp, neg)
+function scale(::Type{T}, FT::FloatType, v, exp, neg, f::F) where {T, F}
+    if T === Float16 || FT == FLOAT16
+        return handlef(__scale(Float16, _unsigned(v), exp, neg), f)
+    elseif T === Float32 || FT == FLOAT32
+        return handlef(__scale(Float32, _unsigned(v), exp, neg), f)
+    elseif T === Float64 || FT == FLOAT64
+        return handlef(__scale(Float64, _unsigned(v), exp, neg), f)
+    else
+        return handlef(__scale(BigFloat, _unsigned(v), exp, neg), f)
+    end
 end
 
 function __scale(::Type{T}, v, exp, neg) where {T}

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -97,8 +97,14 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
 end
 
 @inline function typeparser(::Type{Number}, source, pos, len, b, code, pl, opts)
+    local x
+    pos, code = parsenumber(source, pos, len, b, y -> (x = y))
+    return pos, code, PosLen(pl.pos, pos - pl.pos), x
+end
+
+@inline function parsenumber(source, pos, len, b, f::F) where {F}
     startpos = pos
-    startcode = code
+    code = startcode = SUCCESS
     # begin parsing
     neg = b == UInt8('-')
     if neg || b == UInt8('+')
@@ -111,14 +117,16 @@ end
     end
     b = peekbyte(source, pos)
     # parse rest of number
-    digits = Int64(0)
-    x, code, pos = parsedigits(Number, source, pos, len, b, code, opts, digits, neg, startpos)
-    if (x === Inf || x === -Inf) && !specialvalue(code)
+    _, code, pos = parsedigits(Number, source, pos, len, b, code, OPTIONS, Int64(0), neg, startpos, f)
+    if invalid(code)
         # by default, parsedigits only has up to Float64 precision; if we overflow
         # let's try BigFloat
-        return typeparser(BigFloat, source, startpos, len, b, startcode, pl, opts)
+        pos, code, _, x = typeparser(BigFloat, source, startpos, len, b, startcode, pl, opts)
+        if ok(code)
+            f(x)
+        end
     end
 
 @label done
-    return pos, code, PosLen(pl.pos, pos - pl.pos), x
+    return pos, code
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -296,7 +296,7 @@ function fastseek!(io::IOBuffer, n::Integer)
     io.ptr = n + 1
     return
 end
-fastseek!(io::AbstractVector{UInt8}, n::Integer) = nothing
+fastseek!(io::Union{AbstractVector{UInt8}, AbstractString}, n::Integer) = nothing
 
 """
     Parsers.readbyte(io::IO)::UInt8
@@ -349,7 +349,7 @@ function incr!(from::IOBuffer)
     return
 end
 
-incr!(::AbstractVector{UInt8}) = nothing
+incr!(::Union{AbstractVector{UInt8}, AbstractString}) = nothing
 peekbyte(from::IO, pos) = peekbyte(from)
 dpeekbyte(from::IO, pos) = dpeekbyte(from)
 function peekbyte(from::AbstractVector{UInt8}, pos)
@@ -361,7 +361,17 @@ function dpeekbyte(from::AbstractVector{UInt8}, pos)
     return b, get(from, pos+1, EOF_BYTE)
 end
 
+function peekbyte(from::AbstractString, pos)
+    @inbounds b = codeunit(from, pos)
+    return b
+end
+function dpeekbyte(from::AbstractString, pos)
+    @inbounds b = codeunit(from, pos)
+    return b, pos > sizeof(from) ? EOF_BYTE : peekbyte(from, pos+1)
+end
+
 eof(::AbstractVector{UInt8}, pos::Integer, len::Integer) = pos > len
+eof(::AbstractString, pos::Integer, len::Integer) = pos > len
 eof(source::IO, pos::Integer, len::Integer) = Base.eof(source)
 eof(io::Base.GenericIOBuffer, pos::Integer, len::Integer) = (io.ptr - 1) >= io.size
 


### PR DESCRIPTION
This is an inherently type-unstable operation where we don't know exactly what type of thing we're going to parse, _even_ once we get into the `typeparser`, which isn't usually the case.

This is about 2x faster in the top-level case by switching to a functional style where you pass in an "applicator" function that gets applied to whatever objecdt we end up with. If a user calls the new `parsenumber` directly, they can get near-native performance with their own applicator.

Perf examples:

Before
```
julia> @btime Parsers.parse(Number, "9223372036854775808")
  294.762 ns (7 allocations: 240 bytes)
9223372036854775808

julia> @btime Parsers.parse(Number, "1.0")
  370.350 ns (9 allocations: 208 bytes)
1.0

julia> @btime Parsers.parse(Number, "1")
  249.674 ns (4 allocations: 112 bytes)
1
```

This PR:
```
julia> @btime Parsers.parse(Number, "1")
  123.481 ns (2 allocations: 48 bytes)
1

julia> @btime Parsers.parse(Number, "1.0")
  218.689 ns (4 allocations: 96 bytes)
1.0

julia> @btime Parsers.parse(Number, "9223372036854775808")
  153.579 ns (3 allocations: 80 bytes)
9223372036854775808
```