### PR TITLE
Fix a few corner cases of new Number parsing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -737,6 +737,11 @@ end
     @test Parsers.parse(Number, "1.0") === 1.0
     @test Parsers.parse(Number, "1.0f0") === 1.0f0
     @test Parsers.parse(Number, "1.0e0") === 1.0e0
+    @test Parsers.parse(Number, "1.") === 1.0
+    @test Parsers.parse(Number, "-1.") === -1.0
+    @test Parsers.parse(Number, "9223372036854775807") === 9223372036854775807
+    @test Parsers.parse(Number, "170141183460469231731687303715884105727") === 170141183460469231731687303715884105727
+    @test Parsers.parse(Number, "0e348") == big"0.0"
     # Int128 literal
     @test Parsers.parse(Number, "9223372036854775808") === 9223372036854775808
     # BigInt


### PR DESCRIPTION
If we encounter a decimal point, ensure we treat the `Number` as float instead of integer. For the case where we were _almost_ overflowing, we eagerly widen, but if we don't actually overflow, we want to "unwiden" back to the next lowest integer type. Also fix a few String parsing cases.

At some point, we'll make parsing from a string more first-class, but for now, it works when calling the Parsers.parsenumber directly.