### PR TITLE
Fix a error handling in UUID parser

### DIFF
--- a/test/hexadecimal.jl
+++ b/test/hexadecimal.jl
@@ -17,6 +17,12 @@ using Parsers
 
             res = Parsers.xparse(UUID, IOBuffer(us), 1, i, _OPTIONS)
             @test Parsers.invalid(res.code)
+
+            res = Parsers.xparse(UUID, view(us, 1:i), 1, i, _OPTIONS)
+            @test Parsers.invalid(res.code)
+
+            res = Parsers.xparse(UUID, IOBuffer(view(us, 1:i)), 1, i, _OPTIONS)
+            @test Parsers.invalid(res.code)
         end
         res = Parsers.xparse(UUID, us, 1, 36, _OPTIONS)
         @test Parsers.ok(res.code)
@@ -51,6 +57,12 @@ using Parsers
             @test Parsers.invalid(res.code)
 
             res = Parsers.xparse(Parsers.SHA1, IOBuffer(ss), 1, i, _OPTIONS)
+            @test Parsers.invalid(res.code)
+
+            res = Parsers.xparse(Parsers.SHA1, view(ss, 1:i), 1, i, _OPTIONS)
+            @test Parsers.invalid(res.code)
+
+            res = Parsers.xparse(Parsers.SHA1, IOBuffer(view(ss, 1:i)), 1, i, _OPTIONS)
             @test Parsers.invalid(res.code)
         end
         res = Parsers.xparse(Parsers.SHA1, ss, 1, 40, _OPTIONS)


### PR DESCRIPTION
We were checking `pos <= len` at the wrong place for `UUID`s which have an insufficient length which lead to a bounds error when we were trying to skip over the malformed bytes. In tests we now also actually shrink the `source`, not just the `len` argument, which covers this error.

Fixes #166