### PR TITLE
Introduce `rounding` option

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -112,7 +112,7 @@ end
   * `stripwhitespace=nothing`: if true, leading and trailing whitespace is stripped from string fields, note that for *quoted* strings however, whitespace is preserved within quotes (but ignored before/after quote characters). To also strip *within* quotes, see `stripquoted`
   * `stripquoted=false`: if true, whitespace is also stripped within quoted strings. If true, `stripwhitespace` is also set to true.
   * `groupmark=nothing`: optionally specify a single-byte character denoting the number grouping mark, this allows parsing of numbers that have, e.g., thousand separators (`1,000.00`).
-  * `rounding=RoundNearest`: optionally specify a rounding mode to use when parsing. Valid values are `RoundNearest`, `RoundToZero`. No rounding means an `Inexact` error will be thrown if the inputs cannot be represented without loss of precision.
+  * `rounding=RoundNearest`: optionally specify a rounding mode to use when parsing. No rounding means the result will be marked with `INEXACT` code if the value is not exactly representable in the target type.
 """
 struct Options
     flags::Flags

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -356,7 +356,7 @@ end
                     code |= INVALID
                     x = f === nothing ? x : nothing
                 else
-                    x, code = scale(T, FT, digits, -signed(frac), neg, code, ndigits, f)
+                    x, code = scale(T, FT, digits, -signed(frac), neg, code, ndigits, f, options)
                     code |= OK | EOF
                 end
                 @goto done
@@ -414,7 +414,7 @@ end
                 x = f === nothing ? x : nothing
                 @goto done
             else
-                x, code = scale(T, FT, digits, -signed(frac), neg, code, ndigits, f)
+                x, code = scale(T, FT, digits, -signed(frac), neg, code, ndigits, f, options)
             end
         else
             x = handlef(ifelse(neg, -T(digits), T(digits)), f)
@@ -445,7 +445,7 @@ end
                 code |= INVALID
                 x = f === nothing ? x : nothing
             else
-                x, code = scale(T, FT, digits, ee, neg, code, ndigits, f)
+                x, code = scale(T, FT, digits, ee, neg, code, ndigits, f, options)
                 code |= OK | EOF
             end
             @goto done
@@ -458,7 +458,7 @@ end
                 code |= INVALID
                 x = f === nothing ? x : nothing
             else
-                x, code = scale(T, FT, digits, ifelse(negexp, -signed(exp), signed(exp)) - signed(frac), neg, code, ndigits, f)
+                x, code = scale(T, FT, digits, ifelse(negexp, -signed(exp), signed(exp)) - signed(frac), neg, code, ndigits, f, options)
                 code |= OK
             end
             @goto done
@@ -494,7 +494,7 @@ pow10(::Type{BigFloat}, e) = (@inbounds v = F64_SHORT_POWERS[e+1]; return v)
 _unsigned(x::BigInt) = x
 _unsigned(x) = unsigned(x)
 
-@inline function scale(::Type{T}, FT::FloatType, v, exp, neg, code, ndigits, f::F) where {T, F}
+@inline function scale(::Type{T}, FT::FloatType, v, exp, neg, code, ndigits, f::F, ::Options) where {T, F}
     if T === Float64
         return handlef(__scale(Float64, _unsigned(v), exp, neg), f), code
     elseif T === Float32


### PR DESCRIPTION
This is useful for `FixedDecimal`s, but it would also be useful when parsing `DateTimes` with nanosecond resolution, at least I always had to import them as strings, strip the last couple of digits, and parse again since which is just poor mans rounding. `nothing`, the default value for `rounding`, should mark the value as invalid if it cannot be represented exactly without rounding (do we need `INEXACT` code?)

Best paired with a `Conf`/`TypeParser` approach a la #131 because for some columns rounding might be acceptable but for others, it might not.