### PR TITLE
When delim=groupmark=`x`, treat `x` as delim unless input is quoted 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Parsers"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "2.7.2"
+version = "2.8.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -111,7 +111,7 @@ end
   * `ignoreemptylines=false`: after parsing a value, if a newline is detected, another immediately proceeding newline will be checked for and consumed
   * `stripwhitespace=nothing`: if true, leading and trailing whitespace is stripped from string fields, note that for *quoted* strings however, whitespace is preserved within quotes (but ignored before/after quote characters). To also strip *within* quotes, see `stripquoted`
   * `stripquoted=false`: if true, whitespace is also stripped within quoted strings. If true, `stripwhitespace` is also set to true.
-  * `groupmark=nothing`: optionally specify a single-byte character denoting the number grouping mark, this allows parsing of numbers that have, e.g., thousand separators (`1 000.00`). When the `groupmark` is ambiguous with the `delim`, the user must quote the number if it contains group marks.
+  * `groupmark=nothing`: optionally specify a single-byte character denoting the number grouping mark, this allows parsing of numbers that have, e.g., thousand separators (`1,000.00`). When the `groupmark` is ambiguous with the `delim`, the user must quote the number if it contains group marks.
   * `rounding=RoundNearest`: optionally specify a rounding mode to use when parsing. No rounding means the result will be marked with `INEXACT` code if the value is not exactly representable in the target type.
 """
 struct Options

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -446,6 +446,16 @@ function checkdelim!(source::AbstractVector{UInt8}, pos, len, options::Options)
     return pos
 end
 
+@inline function _has_groupmark(opts::Options, code::ReturnCode)
+    if opts.groupmark !== nothing
+        isquoted = (code & QUOTED) != 0
+        if isquoted || (opts.groupmark != opts.delim)
+            return true
+        end
+    end
+    return false
+end
+
 include("ints.jl")
 include("floats.jl")
 include("strings.jl")

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -235,6 +235,12 @@ rettype(::Type{T}) where {T} = T === Number ? Nothing : T
     anydigits = false
     has_groupmark = options.groupmark !== nothing
     groupmark0 = something(options.groupmark, 0xff) - UInt8('0')
+    isquoted = (code & QUOTED) != 0 # check if the bit is set
+    if !isquoted
+        if options.groupmark == options.delim
+            has_groupmark = false
+        end
+    end
 
     # we already previously checked if `b` was decimal or a digit, so don't need to check explicitly again
     if b != options.decimal

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -233,14 +233,8 @@ rettype(::Type{T}) where {T} = T === Number ? Nothing : T
 @inline function parsedigits(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, overflow_invalid::Bool=false, ndigits::Int=0, f::F=nothing) where {T, IntType, F}
     x = zero(T)
     anydigits = false
-    has_groupmark = options.groupmark !== nothing
+    has_groupmark = _has_groupmark(options, code)
     groupmark0 = something(options.groupmark, 0xff) - UInt8('0')
-    isquoted = (code & QUOTED) != 0 # check if the bit is set
-    if !isquoted
-        if options.groupmark == options.delim
-            has_groupmark = false
-        end
-    end
 
     # we already previously checked if `b` was decimal or a digit, so don't need to check explicitly again
     if b != options.decimal

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -7,14 +7,8 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
 @inline function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) where {T <: Integer}
     x = zero(T)
     neg = false
-    has_groupmark = opts.groupmark !== nothing
+    has_groupmark = _has_groupmark(opts, code)
     groupmark0 = something(opts.groupmark, 0xff) - UInt8('0')
-    isquoted = (code & QUOTED) != 0 # check if the bit is set
-    if !isquoted
-        if opts.groupmark == opts.delim
-            has_groupmark = false
-        end
-    end
     # start actual int parsing
     neg = b == UInt8('-')
     if neg || b == UInt8('+')

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -9,6 +9,12 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
     neg = false
     has_groupmark = opts.groupmark !== nothing
     groupmark0 = something(opts.groupmark, 0xff) - UInt8('0')
+    isquoted = (code & QUOTED) != 0 # check if the bit is set
+    if !isquoted
+        if opts.groupmark == opts.delim
+            has_groupmark = false
+        end
+    end
     # start actual int parsing
     neg = b == UInt8('-')
     if neg || b == UInt8('+')

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -369,42 +369,42 @@ end
 @test Parsers.tryparse(Float64, "0e+") === nothing
 
 @testset "groupmark" begin
-    @test Parsers.xparse(Float64, "100,000,000.99"; groupmark=',').val == 100_000_000.99
-    @test Parsers.xparse(Float64, "100,000,000"; groupmark=',').val == 100_000_000.0
-    @test Parsers.xparse(Float64, "1,0,0,0,0,0,0,0,0.99"; groupmark=',').val == 100_000_000.99
+    # xparse2 is used for parsing inputs with a single value in them,
+    # so when delims==groupmarks, we assume what we see are groupmarks
+    @test let case = "1,0,0,0,0,0,0,0,099e-2"; Parsers.xparse2(Float32, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(','))).val ≈ 100_000_000.99 end
+    @test let case = "100,000,00099e-2"; Parsers.xparse2(Float32, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(','))).val ≈ 100_000_000.99 end
+    @test let case = "100,000,000.99"; Parsers.xparse2(Float32, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(','))).val ≈ 100_000_000.99 end
+    @test let case = "100,000,000"; Parsers.xparse2(Float32, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(','))).val ≈ 100_000_000 end
+    @test let case = "1 0 0 0 0 0 0 0 099e-2"; Parsers.xparse2(Float32, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(' '))).val ≈ 100_000_000.99 end
+    @test let case = "100 000 00099e-2"; Parsers.xparse2(Float32, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(' '))).val ≈ 100_000_000.99 end
+    @test let case = "100 000 000.99"; Parsers.xparse2(Float32, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(' '))).val ≈ 100_000_000.99 end
+    @test let case = "100 000 000"; Parsers.xparse2(Float32, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(' '))).val ≈ 100_000_000 end
+
+    @test let case = "1,0,0,0,0,0,0,0,099e-2"; Parsers.xparse2(Float64, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(','))).val ≈ 100_000_000.99 end
+    @test let case = "100,000,00099e-2"; Parsers.xparse2(Float64, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(','))).val ≈ 100_000_000.99 end
+    @test let case = "100,000,000.99"; Parsers.xparse2(Float64, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(','))).val ≈ 100_000_000.99 end
+    @test let case = "100,000,000"; Parsers.xparse2(Float64, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(','))).val ≈ 100_000_000 end
+    @test let case = "1 0 0 0 0 0 0 0 099e-2"; Parsers.xparse2(Float64, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(' '))).val ≈ 100_000_000.99 end
+    @test let case = "100 000 00099e-2"; Parsers.xparse2(Float64, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(' '))).val ≈ 100_000_000.99 end
+    @test let case = "100 000 000.99"; Parsers.xparse2(Float64, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(' '))).val ≈ 100_000_000.99 end
+    @test let case = "100 000 000"; Parsers.xparse2(Float64, case, 1, length(case), Parsers._get_default_options(groupmark=UInt8(' '))).val ≈ 100_000_000 end
+
+
     @test Parsers.xparse(Float64, "1 0 0 0 0 0 0 0 0.99"; groupmark=' ').val == 100_000_000.99
     @test Parsers.xparse(Float64, "100000000.99"; groupmark=',').val == 100_000_000.99
     @test Parsers.xparse(Float64, "100000000.99,aaa"; groupmark=',') == Parsers.Result{Float64}(OK | DELIMITED, 13, 1.0000000099e8)
     @test Parsers.xparse(Float64, "\"100,000,000.99\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(13), 17, 1.0000000099e8)
-    @test Parsers.xparse(Float64, "100,000,000.99,100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(9), 15, 1.0000000099e8)
     @test Parsers.xparse(Float64, "\"100,000,000\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(13), 14, 1.0e8)
-    res = Parsers.xparse(Float64, "100,000,000,aaa"; groupmark=',')
-    @test res.code == EOF | INVALID | INVALID_DELIMITER
-    @test res.tlen == 15
 
-    @test Parsers.xparse(Float32, "100,000,000.99"; groupmark=',').val ≈ 100_000_000.99
-    @test Parsers.xparse(Float32, "100,000,000"; groupmark=',').val ≈ 100_000_000.0
-    @test Parsers.xparse(Float32, "1,0,0,0,0,0,0,0,0.99"; groupmark=',').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "1 0 0 0 0 0 0 0 0.99"; groupmark=' ').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "100000000.99"; groupmark=',').val ≈ 100_000_000.99
-    res = Parsers.xparse(Float32, "100000000.99,aaa"; groupmark=',')
-    @test res.code == OK | DELIMITED
-    @test res.tlen == 13
-    @test res.val ≈ 100_000_000.99
-    res = Parsers.xparse(Float32, "100,000,000,aaa"; groupmark=',')
-    @test res.code == EOF | INVALID | INVALID_DELIMITER
-    @test res.tlen == 15
 
-    @test Parsers.xparse(Float64, "100,000,00099e-2"; groupmark=',').val == 100_000_000.99
-    @test Parsers.xparse(Float64, "1,0,0,0,0,0,0,0,099e-2"; groupmark=',').val == 100_000_000.99
     @test Parsers.xparse(Float64, "1 0 0 0 0 0 0 0 099e-2"; groupmark=' ').val == 100_000_000.99
     @test Parsers.xparse(Float64, "10000000099e-2"; groupmark=',').val == 100_000_000.99
     @test Parsers.xparse(Float64, "10000000099e-2,aaa"; groupmark=',') == Parsers.Result{Float64}(OK | DELIMITED, 15, 1.0000000099e8)
     @test Parsers.xparse(Float64, "\"10000000099e-2\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(13), 17, 1.0000000099e8)
     @test Parsers.xparse(Float64, "10000000099e-2,100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(9), 15, 1.0000000099e8)
 
-    @test Parsers.xparse(Float32, "100,000,00099e-2"; groupmark=',').val ≈ 100_000_000.99
-    @test Parsers.xparse(Float32, "1,0,0,0,0,0,0,0,099e-2"; groupmark=',').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "1 0 0 0 0 0 0 0 099e-2"; groupmark=' ').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "10000000099e-2"; groupmark=',').val ≈ 100_000_000.99
     res = Parsers.xparse(Float32, "10000000099e-2,aaa"; groupmark=',')

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -386,21 +386,55 @@ end
             @test Parsers.parse(T, "100 000 000", groupmark(' ')) ≈ 100_000_000
         end
     end
+    @test Parsers.xparse(Float64, "100_000_000.99"; groupmark='_').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "100_000_000"; groupmark='_').val == 100_000_000.0
+    @test Parsers.xparse(Float64, "1_0_0_0_0_0_0_0_0.99"; groupmark='_').val == 100_000_000.99
 
     @test Parsers.xparse(Float64, "1 0 0 0 0 0 0 0 0.99"; groupmark=' ').val == 100_000_000.99
     @test Parsers.xparse(Float64, "100000000.99"; groupmark=',').val == 100_000_000.99
     @test Parsers.xparse(Float64, "100000000.99,aaa"; groupmark=',') == Parsers.Result{Float64}(OK | DELIMITED, 13, 1.0000000099e8)
     @test Parsers.xparse(Float64, "\"100,000,000.99\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(13), 17, 1.0000000099e8)
+    @test Parsers.xparse(Float64, "100,000,000.99,100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(9), 4, 100.0)
+    @test Parsers.xparse(Float64, "100_000_000.99,100"; groupmark='_', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(9), 15, 1.0000000099e8)
     @test Parsers.xparse(Float64, "\"100,000,000\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(13), 14, 1.0e8)
+    res = Parsers.xparse(Float64, "100,000,000,aaa"; groupmark=',')
+    @test res.code == OK | DELIMITED
+    @test res.tlen == 4
+    res = Parsers.xparse(Float64, "100_000_000,aaa"; groupmark='_')
+    @test res.code == OK | DELIMITED
+    @test res.tlen == 12
 
+    @test Parsers.xparse(Float32, "100_000_000.99"; groupmark='_').val ≈ 100_000_000.99
+    @test Parsers.xparse(Float32, "100_000_000"; groupmark='_').val ≈ 100_000_000.0
+    @test Parsers.xparse(Float32, "1_0_0_0_0_0_0_0_0.99"; groupmark='_').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "1 0 0 0 0 0 0 0 0.99"; groupmark=' ').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "100000000.99"; groupmark=',').val ≈ 100_000_000.99
+    res = Parsers.xparse(Float32, "100000000.99,aaa"; groupmark=',')
+    @test res.code == OK | DELIMITED
+    @test res.tlen == 13
+    @test res.val ≈ 100_000_000.99
+    res = Parsers.xparse(Float32, "100,000,000,aaa"; groupmark=',')
+    @test res.code == OK | DELIMITED
+    @test res.tlen == 4
+    res = Parsers.xparse(Float32, "100_000_000,aaa"; groupmark='_')
+    @test res.code == OK | DELIMITED
+    @test res.tlen == 12
+
+    @test Parsers.xparse(Float64, "100,000,00099e-2"; groupmark=',').val == 100.0
+    @test Parsers.xparse(Float64, "100_000_00099e-2"; groupmark='_').val == 100_000_000.99
+    @test Parsers.xparse(Float64, "1,0,0,0,0,0,0,0,099e-2"; groupmark=',').val == 1.0
+    @test Parsers.xparse(Float64, "1_0_0_0_0_0_0_0_099e-2"; groupmark='_').val == 100_000_000.99
 
     @test Parsers.xparse(Float64, "1 0 0 0 0 0 0 0 099e-2"; groupmark=' ').val == 100_000_000.99
     @test Parsers.xparse(Float64, "10000000099e-2"; groupmark=',').val == 100_000_000.99
     @test Parsers.xparse(Float64, "10000000099e-2,aaa"; groupmark=',') == Parsers.Result{Float64}(OK | DELIMITED, 15, 1.0000000099e8)
     @test Parsers.xparse(Float64, "\"10000000099e-2\",100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(13), 17, 1.0000000099e8)
     @test Parsers.xparse(Float64, "10000000099e-2,100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(9), 15, 1.0000000099e8)
+
+    @test Parsers.xparse(Float32, "100,000,00099e-2"; groupmark=',').val ≈ 100.0
+    @test Parsers.xparse(Float32, "100_000_00099e-2"; groupmark='_').val ≈ 100_000_000.99
+    @test Parsers.xparse(Float32, "1,0,0,0,0,0,0,0,099e-2"; groupmark=',').val ≈ 1.0
+    @test Parsers.xparse(Float32, "1_0_0_0_0_0_0_0_099e-2"; groupmark='_').val ≈ 100_000_000.99
 
     @test Parsers.xparse(Float32, "1 0 0 0 0 0 0 0 099e-2"; groupmark=' ').val ≈ 100_000_000.99
     @test Parsers.xparse(Float32, "10000000099e-2"; groupmark=',').val ≈ 100_000_000.99


### PR DESCRIPTION
co-authored with @Drvi 

When parsing unquoted numbers, and `delim` and `groupmark` are set to the same character, what should happen?
e.g. `"1,foo"` or `"1,\"foo\""` or `"1,2.3,foo"` or `"1,2.3,\"foo\""`?

On `main` there is no documented behaviour for this situation.

In practice current behaviour on `main` is:
```julia
julia> for T in (Int, Float64)
          println(T)
          for c in ("1,foo","1,\"foo\"","1,2.3,foo","1,2.3,\"foo\"")
              print(rpad(repr(c), 15), " => ")
              println(Parsers.xparse(T, c; delim=',', groupmark=','))
           end
       end
```
```julia
Int64
"1,foo"         => Parsers.Result{Int64}(code=`INVALID: EOF | INVALID_DELIMITER `, tlen=5, val=1)
"1,\"foo\""     => Parsers.Result{Int64}(code=`INVALID: EOF | INVALID_DELIMITER `, tlen=7, val=1)
"1,2.3,foo"     => Parsers.Result{Int64}(code=`INVALID: OK | DELIMITED | INVALID_DELIMITER `, tlen=6, val=12)
"1,2.3,\"foo\"" => Parsers.Result{Int64}(code=`INVALID: OK | DELIMITED | INVALID_DELIMITER `, tlen=6, val=12)
Float64
"1,foo"         => Parsers.Result{Float64}(code=`INVALID: EOF | INVALID_DELIMITER `, tlen=5, val=0.0)
"1,\"foo\""     => Parsers.Result{Float64}(code=`INVALID: EOF | INVALID_DELIMITER `, tlen=7, val=0.0)
"1,2.3,foo"     => Parsers.Result{Float64}(code=`SUCCESS: OK | DELIMITED `, tlen=6, val=12.3)
"1,2.3,\"foo\"" => Parsers.Result{Float64}(code=`SUCCESS: OK | DELIMITED `, tlen=6, val=12.3)
```
With this PR the proposed behaviour is:
```julia
Int64
"1,foo"         => Parsers.Result{Int64}(code=`SUCCESS: OK | DELIMITED `, tlen=2, val=1)
"1,\"foo\""     => Parsers.Result{Int64}(code=`SUCCESS: OK | DELIMITED `, tlen=2, val=1)
"1,2.3,foo"     => Parsers.Result{Int64}(code=`SUCCESS: OK | DELIMITED `, tlen=2, val=1)
"1,2.3,\"foo\"" => Parsers.Result{Int64}(code=`SUCCESS: OK | DELIMITED `, tlen=2, val=1)
Float64
"1,foo"         => Parsers.Result{Float64}(code=`SUCCESS: OK | DELIMITED `, tlen=2, val=1.0)
"1,\"foo\""     => Parsers.Result{Float64}(code=`SUCCESS: OK | DELIMITED `, tlen=2, val=1.0)
"1,2.3,foo"     => Parsers.Result{Float64}(code=`SUCCESS: OK | DELIMITED `, tlen=2, val=1.0)
"1,2.3,\"foo\"" => Parsers.Result{Float64}(code=`SUCCESS: OK | DELIMITED `, tlen=2, val=1.0)
```

That is, the current behaviour on `main` is to "try" to treat the character as a groupmark if possible, e.g. with `Float64` the input `"1,2.3,foo"` parses to `12.3` with the first `,` being interpreted as a groupmark due to the following number, but `"1,foo"` parses to `0.0` (not `1.0`). And with`Int` `"1,foo"` parses to `1`  but is marked `INVALID` whereas with `Float64` `1,2.3,foo` parses to `12.3` but is marked `OK`. These inconsistencies are due to the parsers having no principled approach to resolving the ambiguous `,` character.

This PR changes the parsers to instead treat the character as a delim unless inside a quoted field. i.e. when groupmark and delim are the same (e.g. both `,`) the input `1000,foo` and `\"1,000\",foo"` both parse to `1000`, but `1,000,foo` parses to `1`. 

This brings groupmark inline with how we handle special or ambiguous characters when parsing to `String`, i.e. they can only appear in quoted values

**Is this a breaking change?**

The old behaviour was not documented, inconsistent, and an artefact of implementation details. However, this PR does change the behaviour of some existing tests, since unfortunately our tests were not written with a careful eye for `delim==groupmark` cases. 

The tests actually tested _both_ that we could and that we couldn't parse numbers in these cases, e.g. we had both
```julia
@test Parsers.xparse(Float64, "100,000,000.99,100"; groupmark=',', openquotechar='"', closequotechar='"') == Parsers.Result{Float64}(Int16(9), 15, 1.0000000099e8)
```
i.e. testing we got `code='SUCCESS: OK | DELIMITED '` and `val=1.0000000099e8`
and
```julia
res = Parsers.xparse(Int64, "100,000,000,aaa"; groupmark=',')
@test res.code == EOF | INVALID | INVALID_DELIMITER
```
i.e. testing we code `code='INVALID: EOF | INVALID_DELIMITER '` and not testing the value

So whilst it's always possible for someone to come to rely on a bug, i don't think there's any consistent behaviour here that someone could reasonably have been relying upon

Secondly, all tests in CSV.jl, WeakRefStrings.jl, JSON.jl, InlineStrings.jl, PowerFlowData.jl, JSON3.jl pass with this change, which gives some further validation that the old behaviour wasn't relied upon (at least as far as these test suites reflect usage).

Since breaking changes are not entirely free (all the dependency packages need to update, even though they don't require any code changes), i'll mark this as a new feature (we now support `groupmark==delim` with consistent semantics).