### PR TITLE
Add ChunkedCSV.jl to the integration tests workflow

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -28,6 +28,7 @@ jobs:
           - {user: JuliaStrings, repo: InlineStrings.jl}
           - {user: nickrobinson251, repo: PowerFlowData.jl}
           - {user: quinnj, repo: JSON3.jl}
+          - {user: RelationalAI, repo: ChunkedCSV.jl}
 
     steps:
       - uses: actions/checkout@v2

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,11 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+Aqua = "0.8"
 Dates = "1.6"
 PrecompileTools = "1"
+Serialization = "1"
+Test = "1"
 UUIDs = "1.6"
 julia = "1.6"
 


### PR DESCRIPTION
- PRs to Parsers.jl will now run the ChunkedCSV.jl tests to ensure there is no accidental breakage to that package
  -  e.g. for this PR: https://github.com/JuliaData/Parsers.jl/actions/runs/7021727622/job/19104488100?pr=187