### PR TITLE
Fix buffer overflow for Julia >=1.11 in `mpfr_strtofr`

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -72,7 +72,7 @@ function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, opt
         readbytes!(source, str, vlen)
         fastseek!(source, _pos) # reset IO to earlier position
     end
-    str = Base.cconvert(Cstring, String(copy(str)))
+    str = Base.cconvert(Cstring, String(str isa Vector{UInt8} ? copy(str) : str))
     GC.@preserve str begin
         ptr = pointer(str, strpos)
         endptr = Ref{Ptr{UInt8}}()

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -72,11 +72,11 @@ function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, opt
         readbytes!(source, str, vlen)
         fastseek!(source, _pos) # reset IO to earlier position
     end
-    str = String(str)
+    str = Base.cconvert(Cstring, String(str))
     GC.@preserve str begin
         ptr = pointer(str, strpos)
         endptr = Ref{Ptr{UInt8}}()
-        err = ccall((:mpfr_strtofr, :libmpfr), Int32, (Ref{BigFloat}, Cstring, Ref{Ptr{UInt8}}, Int32, Base.MPFR.MPFRRoundingMode), z, ptr, endptr, base, rounding)
+        err = ccall((:mpfr_strtofr, :libmpfr), Int32, (Ref{BigFloat}, Ptr{UInt8}, Ref{Ptr{UInt8}}, Int32, Base.MPFR.MPFRRoundingMode), z, ptr, endptr, base, rounding)
         code |= endptr[] == ptr ? INVALID : OK
         pos += Int(endptr[] - ptr)
         return pos, code, PosLen(pl.pos, max(0, pos - pl.pos)), z

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -72,10 +72,11 @@ function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, opt
         readbytes!(source, str, vlen)
         fastseek!(source, _pos) # reset IO to earlier position
     end
+    str = String(str)
     GC.@preserve str begin
         ptr = pointer(str, strpos)
         endptr = Ref{Ptr{UInt8}}()
-        err = ccall((:mpfr_strtofr, :libmpfr), Int32, (Ref{BigFloat}, Ptr{UInt8}, Ref{Ptr{UInt8}}, Int32, Base.MPFR.MPFRRoundingMode), z, ptr, endptr, base, rounding)
+        err = ccall((:mpfr_strtofr, :libmpfr), Int32, (Ref{BigFloat}, Cstring, Ref{Ptr{UInt8}}, Int32, Base.MPFR.MPFRRoundingMode), z, ptr, endptr, base, rounding)
         code |= endptr[] == ptr ? INVALID : OK
         pos += Int(endptr[] - ptr)
         return pos, code, PosLen(pl.pos, max(0, pos - pl.pos)), z

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -72,7 +72,13 @@ function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, opt
         readbytes!(source, str, vlen)
         fastseek!(source, _pos) # reset IO to earlier position
     end
-    str = Base.cconvert(Cstring, String(str isa Vector{UInt8} ? copy(str) : str))
+    @static if v"1.11-" <= VERSION < v"1.12-"
+    	str = (str isa Vector{UInt8} || str isa Memory{UInt8}) ? copy(str) : str
+    else 
+    	str = (str isa Vector{UInt8}) ? copy(str) : str
+    end
+
+    str = Base.cconvert(Cstring, String(str))
     GC.@preserve str begin
         ptr = pointer(str, strpos)
         endptr = Ref{Ptr{UInt8}}()

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -72,7 +72,7 @@ function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, opt
         readbytes!(source, str, vlen)
         fastseek!(source, _pos) # reset IO to earlier position
     end
-    str = Base.cconvert(Cstring, String(str))
+    str = Base.cconvert(Cstring, String(copy(str)))
     GC.@preserve str begin
         ptr = pointer(str, strpos)
         endptr = Ref{Ptr{UInt8}}()


### PR DESCRIPTION
Closes #189. If a new release could be cut once this is merged that would be useful.