### PR TITLE
Mark Inf/-Inf as special value in float parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: CI
 on:
-  pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
-    tags: '*'
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -27,21 +27,12 @@ jobs:
             version: '1'
             arch: x86
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -439,10 +439,10 @@ end
 _xparse2(conf::AbstractConf{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, opts::Options=OPTIONS, ::Type{S}=returntype(T)) where {T, S} =
     Result(whitespace(false, false, false, true)(typeparser(opts)))(conf, source, pos, len, S)
 
-@inline xparse2(::Type{T}, source::SourceType, pos, len, options=OPTIONS, ::Type{S}=returntype(T)) where {T, S} =
+xparse2(::Type{T}, source::SourceType, pos, len, options=OPTIONS, ::Type{S}=returntype(T)) where {T, S} =
     result(T, xparse2(conf(T, options), source, pos, len, options, S))
 
-@inline function xparse2(conf::AbstractConf{T}, source::SourceType, pos, len, options=OPTIONS, ::Type{S}=returntype(T)) where {T, S}
+function xparse2(conf::AbstractConf{T}, source::SourceType, pos, len, options=OPTIONS, ::Type{S}=returntype(T)) where {T, S}
     buf = source isa AbstractString ? codeunits(source) : source
     if T === Number || supportedtype(T)
         return _xparse2(conf, buf, pos, len, options, S)
@@ -483,7 +483,7 @@ function checkdelim!(source::AbstractVector{UInt8}, pos, len, options::Options)
     return pos
 end
 
-@inline function _has_groupmark(opts::Options, code::ReturnCode)
+function _has_groupmark(opts::Options, code::ReturnCode)
     if opts.groupmark !== nothing
         isquoted = (code & QUOTED) != 0
         if isquoted || (opts.groupmark != opts.delim)

--- a/src/bools.jl
+++ b/src/bools.jl
@@ -1,7 +1,7 @@
 const DEFAULT_TRUE = "true"
 const DEFAULT_FALSE = "false"
 
-@inline function typeparser(::AbstractConf{Bool}, source, pos, len, b, code, pl, options::Options)
+function typeparser(::AbstractConf{Bool}, source, pos, len, b, code, pl, options::Options)
     x = false
     trues = options.trues
     falses = options.falses

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -130,13 +130,13 @@ maxdigits(d::Dates.DatePart) = d.fixed ? d.width : typemax(Int64)
 
 for c in "yYmdHIMS"
     @eval begin
-        @inline function tryparsenext(d::Dates.DatePart{$c}, source, pos, len, b, code)
+        function tryparsenext(d::Dates.DatePart{$c}, source, pos, len, b, code)
             return tryparsenext_base10(source, pos, len, b, code, maxdigits(d))
         end
     end
 end
 
-@inline function tryparsenext_base10(source, pos, len, b, code, maxdigits)
+function tryparsenext_base10(source, pos, len, b, code, maxdigits)
     x::Int64 = 0
     b -= UInt8('0')
     if b > 0x09
@@ -256,7 +256,7 @@ for (tok, fn) in zip("uUeE", Any[Dates.monthabbr_to_value, Dates.monthname_to_va
     end
 end
 
-@inline function tryparsenext(d::Dates.DatePart{'s'}, source, pos, len, b, code, options)
+function tryparsenext(d::Dates.DatePart{'s'}, source, pos, len, b, code, options)
     ms0, newpos, b, code = tryparsenext_base10(source, pos, len, b, code, maxdigits(d))
     invalid(code) && return ms0, newpos, b, code
     rounding = options.rounding
@@ -280,7 +280,7 @@ end
     return ms, newpos, b, code
 end
 
-@inline function tryparsenext(d::Delim{<:AbstractChar}, source, pos, len, b, code)
+function tryparsenext(d::Delim{<:AbstractChar}, source, pos, len, b, code)
     u = bswap(reinterpret(UInt32, d.d))
     while true
         if b != (u & 0x000000ff)
@@ -340,7 +340,7 @@ function tryparsenext(tok, source, pos, len, b, code)::Tuple{Any, Int, UInt8, Re
     return val, pos, b, code
 end
 
-@inline function typeparser(::AbstractConf{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, b, code, pl, options) where {T <: Dates.TimeType}
+function typeparser(::AbstractConf{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, b, code, pl, options) where {T <: Dates.TimeType}
     fmt = options.dateformat
     df = fmt === nothing ? default_format(T) : fmt
     tokens = df.tokens

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -50,7 +50,7 @@ end
 @enum FloatType FLOAT16 FLOAT32 FLOAT64 BIGFLOAT
 
 # for non SupportedFloat Reals, parse as Float64, then convert
-@inline function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, options) where {T <: Real}
+function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, options) where {T <: Real}
     pos, code, pl, x = typeparser(DefaultConf{Float64}(), source, pos, len, b, code, pl, options)
     return pos, code, pl, T(x)
 end
@@ -75,14 +75,14 @@ function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, opt
     GC.@preserve str begin
         ptr = pointer(str, strpos)
         endptr = Ref{Ptr{UInt8}}()
-        err = ccall((:mpfr_strtofr, :libmpfr), Int32, (Ref{BigFloat}, Ptr{UInt8}, Ref{Ptr{UInt8}}, Int32, Base.MPFR.MPFRRoundingMode), z, ptr, endptr, base, rounding)
+        err = ccall((:mpfr_strtofr, :libmpfr), Int32, (Ref{BigFloat}, Cstring, Ref{Ptr{UInt8}}, Int32, Base.MPFR.MPFRRoundingMode), z, ptr, endptr, base, rounding)
         code |= endptr[] == ptr ? INVALID : OK
         pos += Int(endptr[] - ptr)
         return pos, code, PosLen(pl.pos, max(0, pos - pl.pos)), z
     end
 end
 
-@inline function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, options) where {T <: SupportedFloats}
+function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, options) where {T <: SupportedFloats}
     # keep track of starting pos in case of invalid, we can rewind to start of parsing
     startpos = pos
     x = zero(T)
@@ -218,7 +218,7 @@ end
     return pos, code, PosLen(pl.pos, pos - pl.pos), x
 end
 
-@inline function handlef(x::T, f::F) where {T, F}
+function handlef(x::T, f::F) where {T, F}
     if f === nothing
         return x
     else
@@ -240,7 +240,7 @@ getx(x, f) = f === nothing ? x : nothing
 @noinline _parsedigits(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, overflow_invalid::Bool, ndigits::Int, f::F) where {T, IntType, F} =
     parsedigits(conf, source, pos, len, b, code, options, digits, neg, startpos, overflow_invalid, ndigits, f)::Tuple{rettype(T), ReturnCode, Int}
 
-@inline function parsedigits(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, overflow_invalid::Bool=false, ndigits::Int=0, f::F=nothing) where {T, IntType, F}
+function parsedigits(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, overflow_invalid::Bool=false, ndigits::Int=0, f::F=nothing) where {T, IntType, F}
     x = zero(T)
     anydigits = false
     has_groupmark = _has_groupmark(options, code)
@@ -347,7 +347,7 @@ end
 @noinline _parsefrac(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac, overflow_invalid, ndigits, f::F) where {T, IntType, F} =
     parsefrac(conf, source, pos, len, b, code, options, digits, neg, startpos, frac, overflow_invalid, ndigits, f)::Tuple{rettype(T), ReturnCode, Int}
 
-@inline function parsefrac(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac, overflow_invalid, ndigits, f::F) where {T, IntType, F}
+function parsefrac(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac, overflow_invalid, ndigits, f::F) where {T, IntType, F}
     x = zero(T)
     parsedanyfrac = false
     FT = FLOAT64
@@ -444,7 +444,7 @@ end
 @noinline _parseexp(conf::AbstractConf{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT, overflow_invalid, ndigits, f::F) where {T, ExpType, F} =
     parseexp(conf, source, pos, len, b, code, options, digits, neg, startpos, frac, exp, negexp, FT, overflow_invalid, ndigits, f)::Tuple{rettype(T), ReturnCode, Int}
 
-@inline function parseexp(conf::AbstractConf{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT, overflow_invalid, ndigits, f::F) where {T, ExpType, F}
+function parseexp(conf::AbstractConf{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT, overflow_invalid, ndigits, f::F) where {T, ExpType, F}
     x = zero(T)
     # note that `b` has already had `b - UInt8('0')` applied to it for parseexp
     while true
@@ -508,12 +508,12 @@ _unsigned(x::BigInt) = x
 _unsigned(x) = unsigned(x)
 
 # No fractional part or exponent, digits in `v` are already scaled
-@inline function noscale(::AbstractConf{T}, v::Integer, neg::Bool, code, ndigits, f::F, ::Options) where {T, F}
+function noscale(::AbstractConf{T}, v::Integer, neg::Bool, code, ndigits, f::F, ::Options) where {T, F}
     return handlef(ifelse(neg, -T(v), T(v)), f), code
 end
 
 # Digits in `v` need to be scaled by `exp`
-@inline function scale(::AbstractConf{T}, FT::FloatType, v, exp, neg, code, ndigits, f::F, ::Options) where {T, F}
+function scale(::AbstractConf{T}, FT::FloatType, v, exp, neg, code, ndigits, f::F, ::Options) where {T, F}
     if T === Float64
         return handlef(__scale(Float64, _unsigned(v), exp, neg), f), code
     elseif T === Float32
@@ -693,7 +693,7 @@ function _scale(::Type{T}, v::V, exp, neg) where {T, V <: BigInt}
     return convert_and_apply_neg(T, x, neg)
 end
 
-@inline function two_prod(a, b)
+function two_prod(a, b)
     x = UInt128(a) * b
     return UInt64(x >> 64), x % UInt64
 end

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -210,6 +210,9 @@ end
 
     # start parsing digits or decimal point; we start digits as UInt64(0) and can _widen type if needed
     x, code, pos = parsedigits(conf, source, pos, len, b, code, options, UInt64(0), neg, startpos)
+    if !isfinite(x)
+        code |= SPECIAL_VALUE
+    end
 
 @label done
     return pos, code, PosLen(pl.pos, pos - pl.pos), x

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -4,7 +4,7 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
 # if we eventually support non-base 10
 # overflowval(::Type{T}, base) where {T <: Integer} = div(typemax(T) - base + 1, base)
 
-@inline function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) where {T <: Integer}
+function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) where {T <: Integer}
     x = zero(T)
     neg = false
     has_groupmark = _has_groupmark(opts, code)
@@ -98,13 +98,13 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
     return pos, code, PosLen(pl.pos, pos - pl.pos), x
 end
 
-@inline function typeparser(::AbstractConf{Number}, source, pos, len, b, code, pl, opts)
+function typeparser(::AbstractConf{Number}, source, pos, len, b, code, pl, opts)
     x = Ref{Number}()
     pos, code = parsenumber(source, pos, len, b, y -> (x[] = y), opts)
     return pos, code, PosLen(pl.pos, pos - pl.pos), isdefined(x, :x) ? x[] : (0::Number)
 end
 
-@inline function parsenumber(source, pos, len, b, f::F, opts=OPTIONS) where {F}
+function parsenumber(source, pos, len, b, f::F, opts=OPTIONS) where {F}
     startpos = pos
     code = startcode = SUCCESS
     # begin parsing

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -2,7 +2,7 @@ isgreedy(::Type{T}) where {T <: AbstractString} = true
 isgreedy(::Type{Symbol}) = true
 isgreedy(T) = false
 
-@inline function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) where {T <: AbstractString}
+function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) where {T <: AbstractString}
     if quoted(code)
         code |= OK
         return findendquoted(T, source, pos, len, b, code, pl, true, opts.cq, opts.e, opts.flags.stripquoted)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -370,6 +370,9 @@ function text(r)
     if r & SENTINEL > 0
         str *= ", a sentinel value was parsed"
     end
+    if r & SPECIAL_VALUE > 0
+        str *= ", a special value was parsed"
+    end
     if r & ESCAPED_STRING > 0
         str *= ", encountered escape character"
     end
@@ -400,6 +403,7 @@ codes(r) = chop(chop(string(
     ifelse(r & DELIMITED > 0, "DELIMITED | ", ""),
     ifelse(r & NEWLINE > 0, "NEWLINE | ", ""),
     ifelse(r & EOF > 0, "EOF | ", ""),
+    ifelse(r & SPECIAL_VALUE > 0, "SPECIAL_VALUE | ", ""),
     ifelse(r & (~INVALID & INVALID_QUOTED_FIELD) > 0, "INVALID_QUOTED_FIELD | ", ""),
     ifelse(r & (~INVALID & INVALID_DELIMITER) > 0, "INVALID_DELIMITER | ", ""),
     ifelse(r & (~INVALID & OVERFLOW) > 0, "OVERFLOW | ", ""),

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -148,7 +148,7 @@ end
 
 @noinline notsupported() = throw(ArgumentError("Regex matching not supported on this input type"))
 
-@inline function checktoken(source, pos, len, b, token::Token)
+function checktoken(source, pos, len, b, token::Token)
     tok = token.token
     if tok isa UInt8
         check = tok == b
@@ -172,13 +172,13 @@ end
     end
 end
 
-@inline function checktoken(source, pos, len, b, tok::UInt8)
+function checktoken(source, pos, len, b, tok::UInt8)
     check = tok == b
     check && incr!(source)
     return check, pos + check
 end
 
-@inline function checktoken(source::AbstractVector{UInt8}, pos, len, b, tok::RegexAndMatchData)
+function checktoken(source::AbstractVector{UInt8}, pos, len, b, tok::RegexAndMatchData)
     rc = ccall((:pcre2_match_8, Base.PCRE.PCRE_LIB), Cint,
         (Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Csize_t, UInt32, Ptr{Cvoid}, Ptr{Cvoid}),
         tok.re.regex, source, len, pos - 1, tok.re.match_options, tok.data, Base.PCRE.get_local_match_context())
@@ -187,13 +187,13 @@ end
     return check, pos + (!check ? 0 : Base.PCRE.substring_length_bynumber(tok.data, 0))
 end
 
-@inline function checktoken(source::AbstractVector{UInt8}, pos, len, b, tok::String)
+function checktoken(source::AbstractVector{UInt8}, pos, len, b, tok::String)
     sz = sizeof(tok)
     check = (pos + sz - 1) <= len && memcmp(pointer(source, pos), pointer(tok), sz)
     return check, pos + (check * sz)
 end
 
-@inline function checktoken(source::IO, pos, len, b, tok::String)
+function checktoken(source::IO, pos, len, b, tok::String)
     bytes = codeunits(tok)
     startpos = pos
     blen = length(bytes)
@@ -450,7 +450,7 @@ _len_bits(::Union{PosLen31,Type{PosLen31}}) = Base.bitcast(Int64, 0x000000007fff
     throw(ArgumentError("length argument to $T ($len) is too large; max length allowed is $(_max_len(T))"))
 
 for T in (:PosLen, :PosLen31)
-    @eval @inline function $T(pos::Integer, len::Integer, ismissing=false, escaped=false)
+    @eval function $T(pos::Integer, len::Integer, ismissing=false, escaped=false)
         pos > _max_pos($T) && postoolarge($T, pos)
         len > _max_len($T) && lentoolarge($T, len)
         @assert pos >= 0
@@ -500,7 +500,7 @@ _unsafe_string(p, len) = ccall(:jl_pchar_to_string, Ref{String}, (Ptr{UInt8}, In
 getstring(source::Union{IO, AbstractVector{UInt8}}, x::Union{PosLen,PosLen31}, e::Token) =
     getstring(source, x, e.token::UInt8)
 
-@inline function getstring(source::Union{IO, AbstractVector{UInt8}}, x::Union{PosLen,PosLen31}, e::UInt8)
+function getstring(source::Union{IO, AbstractVector{UInt8}}, x::Union{PosLen,PosLen31}, e::UInt8)
     x.escapedvalue && return unescape(source, x, e)
     if source isa AbstractVector{UInt8}
         return _unsafe_string(pointer(source, x.pos), x.len)

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -88,28 +88,28 @@ testcases = [
     (str="1.7976931348623157e308", x=1.7976931348623157e+308, code=(OK | EOF), len=0, tot=0),
     (str="-1.7976931348623157e308", x=-1.7976931348623157e+308, code=(OK | EOF), len=0, tot=0),
     # next float64 - too large
-    (str="1.7976931348623159e308", x=+Inf, code=(OK | EOF), len=0, tot=0),
-    (str="-1.7976931348623159e308", x=-Inf, code=(OK | EOF), len=0, tot=0),
+    (str="1.7976931348623159e308", x=+Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
+    (str="-1.7976931348623159e308", x=-Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
     # the border is ...158079
     # borderline - okay
     (str="1.7976931348623158e308", x=1.7976931348623157e+308, code=(OK | EOF), len=0, tot=0),
     (str="-1.7976931348623158e308", x=-1.7976931348623157e+308, code=(OK | EOF), len=0, tot=0),
     # borderline - too large
-    (str="1.797693134862315808e308", x=+Inf, code=(OK | EOF), len=0, tot=0),
-    (str="-1.797693134862315808e308", x=-Inf, code=(OK | EOF), len=0, tot=0),
+    (str="1.797693134862315808e308", x=+Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
+    (str="-1.797693134862315808e308", x=-Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
 
     # a little too large
     (str="1e308", x=1e+308, code=(OK | EOF), len=0, tot=0),
-    (str="2e308", x=+Inf, code=(OK | EOF), len=0, tot=0),
-    (str="1e309", x=+Inf, code=(OK | EOF), len=0, tot=0),
+    (str="2e308", x=+Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
+    (str="1e309", x=+Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
 
     # way too large
-    (str="1e310", x=+Inf, code=(OK | EOF), len=0, tot=0),
-    (str="-1e310", x=-Inf, code=(OK | EOF), len=0, tot=0),
-    (str="1e400", x=+Inf, code=(OK | EOF), len=0, tot=0),
-    (str="-1e400", x=-Inf, code=(OK | EOF), len=0, tot=0),
-    (str="1e400000", x=+Inf, code=(OK | EOF), len=0, tot=0),
-    (str="-1e400000", x=-Inf, code=(OK | EOF), len=0, tot=0),
+    (str="1e310", x=+Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
+    (str="-1e310", x=-Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
+    (str="1e400", x=+Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
+    (str="-1e400", x=-Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
+    (str="1e400000", x=+Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
+    (str="-1e400000", x=-Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
 
     # denormalized
     (str="1e-305", x=1e-305, code=(OK | EOF), len=0, tot=0),
@@ -131,10 +131,10 @@ testcases = [
 
     # try to overflow exponent
     (str="1e-4294967296", x=0.0, code=(OK | EOF), len=0, tot=0),
-    (str="1e+4294967296", x=+Inf, code=(OK | EOF), len=0, tot=0),
+    (str="1e+4294967296", x=+Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
     (str="1e-18446744073709551616", x=0.0, code=(OK | EOF), len=0, tot=0),
 
-    (str="1e+18446744073709551616", x=+Inf, code=(OK | EOF), len=0, tot=0),
+    (str="1e+18446744073709551616", x=+Inf, code=(OK | EOF | SPECIAL_VALUE), len=0, tot=0),
 
     # Parse errors
     # (str="1e", x=missing, code=(INVALID | EOF), len=0, tot=0),


### PR DESCRIPTION
Minor consistency thing: we were only marking the SPECIAL_VALUE code when parsed explicitly, but it's useful to also know when, for example, Float64 ends up overflowing to -Inf/Inf.