### PR TITLE
Restore `@inline` annotations

### DIFF
--- a/src/Parsers.jl
+++ b/src/Parsers.jl
@@ -439,10 +439,10 @@ end
 _xparse2(conf::AbstractConf{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, opts::Options=OPTIONS, ::Type{S}=returntype(T)) where {T, S} =
     Result(whitespace(false, false, false, true)(typeparser(opts)))(conf, source, pos, len, S)
 
-xparse2(::Type{T}, source::SourceType, pos, len, options=OPTIONS, ::Type{S}=returntype(T)) where {T, S} =
+@inline xparse2(::Type{T}, source::SourceType, pos, len, options=OPTIONS, ::Type{S}=returntype(T)) where {T, S} =
     result(T, xparse2(conf(T, options), source, pos, len, options, S))
 
-function xparse2(conf::AbstractConf{T}, source::SourceType, pos, len, options=OPTIONS, ::Type{S}=returntype(T)) where {T, S}
+@inline function xparse2(conf::AbstractConf{T}, source::SourceType, pos, len, options=OPTIONS, ::Type{S}=returntype(T)) where {T, S}
     buf = source isa AbstractString ? codeunits(source) : source
     if T === Number || supportedtype(T)
         return _xparse2(conf, buf, pos, len, options, S)
@@ -483,7 +483,7 @@ function checkdelim!(source::AbstractVector{UInt8}, pos, len, options::Options)
     return pos
 end
 
-function _has_groupmark(opts::Options, code::ReturnCode)
+@inline function _has_groupmark(opts::Options, code::ReturnCode)
     if opts.groupmark !== nothing
         isquoted = (code & QUOTED) != 0
         if isquoted || (opts.groupmark != opts.delim)

--- a/src/bools.jl
+++ b/src/bools.jl
@@ -1,7 +1,7 @@
 const DEFAULT_TRUE = "true"
 const DEFAULT_FALSE = "false"
 
-function typeparser(::AbstractConf{Bool}, source, pos, len, b, code, pl, options::Options)
+@inline function typeparser(::AbstractConf{Bool}, source, pos, len, b, code, pl, options::Options)
     x = false
     trues = options.trues
     falses = options.falses

--- a/src/components.jl
+++ b/src/components.jl
@@ -1,6 +1,7 @@
 # must be outermost layer
 function Result(parser)
     function(conf::AbstractConf{T}, source, pos, len, ::Type{RT}=T) where {T, RT}
+        Base.@_inline_meta
         startpos = pos
         code = SUCCESS
         b = eof(source, pos, len) ? 0x00 : peekbyte(source, pos)
@@ -35,6 +36,7 @@ emptysentinel(opts::Options) = emptysentinel(opts.flags.checksentinel && isempty
 function emptysentinel(checksent::Bool)
     function(parser)
         function checkemptysentinel(conf::AbstractConf{T}, source, pos, len, b, code, pl) where {T}
+            Base.@_inline_meta
             pos, code, pl, x = parser(conf, source, pos, len, b, code, pl)
             if checksent && pl.len == 0 && (!isgreedy(T) || !quoted(code))
                 code &= ~(OK | INVALID)
@@ -54,6 +56,7 @@ whitespace(opts::Options) = whitespace(opts.flags.spacedelim, opts.flags.tabdeli
 function whitespace(spacedelim, tabdelim, stripquoted, stripwh)
     function(parser)
         function stripwhitespace(conf::AbstractConf{T}, source, pos, len, b, code, pl) where {T}
+            Base.@_inline_meta
             # strip leading whitespace
             if !eof(source, pos, len) && (
                 # pre-quotes, if delim is not whitespace
@@ -108,7 +111,7 @@ function whitespace(spacedelim, tabdelim, stripquoted, stripwh)
     end
 end
 
-function findendquoted(::Type{T}, source, pos, len, b, code, pl, isquoted, cq, e, stripquoted) where {T}
+@inline function findendquoted(::Type{T}, source, pos, len, b, code, pl, isquoted, cq, e, stripquoted) where {T}
     # for quoted fields, find the closing quote character
     # we should be positioned at the correct place to find the closing quote character if everything is as it should be
     # if we don't find the quote character immediately, something's wrong, so mark INVALID
@@ -199,6 +202,7 @@ quoted(opts::Options) = quoted(opts.flags.checkquoted, opts.oq, opts.cq, opts.e,
 function quoted(checkquoted, oq, cq, e, stripquoted)
     function(parser)
         function findquoted(conf::AbstractConf{T}, source, pos, len, b, code, pl) where {T}
+            Base.@_inline_meta
             isquoted = false
             if checkquoted && !eof(source, pos, len)
                 isquoted, pos = checktoken(source, pos, len, b, oq)
@@ -235,6 +239,7 @@ sentinel(opts::Options) = sentinel(opts.flags.checksentinel, opts.sentinel)
 function sentinel(chcksentinel, sentinel)
     function(parser)
         function checkforsentinel(conf::AbstractConf{T}, source, pos, len, b, code, pl) where {T}
+            Base.@_inline_meta
             match, sentinelpos = (!chcksentinel || isempty(sentinel) || eof(source, pos, len)) ? (false, 0) : checktokens(source, pos, len, b, sentinel)
             pos, code, pl, x = parser(conf, source, pos, len, b, code, pl)
             # @show match, sentinelpos, pos, pl
@@ -259,7 +264,7 @@ function sentinel(chcksentinel, sentinel)
     end
 end
 
-function finddelimiter(::Type{T}, source, pos, len, b, code, pl, delim, ignorerepeated, cmt, ignoreemptylines, stripwhitespace) where {T}
+@inline function finddelimiter(::Type{T}, source, pos, len, b, code, pl, delim, ignorerepeated, cmt, ignoreemptylines, stripwhitespace) where {T}
     # now we check for a delimiter; if we don't find it, keep parsing until we do
     # for greedy strings, we need to keep track of the last non-whitespace character
     # if we're stripping whitespace, but note we've already skipped leading whitespace
@@ -359,6 +364,7 @@ delimiter(opts::Options) = delimiter(opts.flags.checkdelim, opts.delim, opts.fla
 function delimiter(checkdelim, delim, ignorerepeated, cmt, ignoreemptylines, stripwhitespace)
     function(parser)
         function _finddelimiter(conf::AbstractConf{T}, source, pos, len, b, code, pl) where {T}
+            Base.@_inline_meta
             pos, code, pl, x = parser(conf, source, pos, len, b, code, pl)
             if eof(source, pos, len) || !checkdelim || delimited(code) || newline(code) # greedy case
                 return pos, code, pl, x
@@ -372,20 +378,21 @@ end
 
 function typeparser(opts::Options)
     function(conf::AbstractConf{T}, source, pos, len, b, code, pl) where {T}
+        Base.@_inline_meta
         return typeparser(conf, source, pos, len, b, code, pl, opts)
     end
 end
 
 # backwards compat
-function typeparser(conf, source, pos, len, b, code, opts::Options)
+@inline function typeparser(conf, source, pos, len, b, code, opts::Options)
     pos, code, pl, x = typeparser(conf, source, pos, len, b, code, poslen(pos, 0), opts)
     return x, code, pos
 end
 
-function typeparser(::Type{T}, source, pos, len, b, code, opts::Options) where {T}
+@inline function typeparser(::Type{T}, source, pos, len, b, code, opts::Options) where {T}
     pos, code, pl, x = typeparser(DefaultConf{T}(), source, pos, len, b, code, poslen(pos, 0), opts)
     return x, code, pos
 end
 
-typeparser(::Type{T}, source, pos, len, b, code, pl) where {T} =
+@inline typeparser(::Type{T}, source, pos, len, b, code, pl) where {T} =
     typeparser(DefaultConf{T}(), source, pos, len, b, code, pl, Options())

--- a/src/dates.jl
+++ b/src/dates.jl
@@ -130,13 +130,13 @@ maxdigits(d::Dates.DatePart) = d.fixed ? d.width : typemax(Int64)
 
 for c in "yYmdHIMS"
     @eval begin
-        function tryparsenext(d::Dates.DatePart{$c}, source, pos, len, b, code)
+        @inline function tryparsenext(d::Dates.DatePart{$c}, source, pos, len, b, code)
             return tryparsenext_base10(source, pos, len, b, code, maxdigits(d))
         end
     end
 end
 
-function tryparsenext_base10(source, pos, len, b, code, maxdigits)
+@inline function tryparsenext_base10(source, pos, len, b, code, maxdigits)
     x::Int64 = 0
     b -= UInt8('0')
     if b > 0x09
@@ -256,7 +256,7 @@ for (tok, fn) in zip("uUeE", Any[Dates.monthabbr_to_value, Dates.monthname_to_va
     end
 end
 
-function tryparsenext(d::Dates.DatePart{'s'}, source, pos, len, b, code, options)
+@inline function tryparsenext(d::Dates.DatePart{'s'}, source, pos, len, b, code, options)
     ms0, newpos, b, code = tryparsenext_base10(source, pos, len, b, code, maxdigits(d))
     invalid(code) && return ms0, newpos, b, code
     rounding = options.rounding
@@ -280,7 +280,7 @@ function tryparsenext(d::Dates.DatePart{'s'}, source, pos, len, b, code, options
     return ms, newpos, b, code
 end
 
-function tryparsenext(d::Delim{<:AbstractChar}, source, pos, len, b, code)
+@inline function tryparsenext(d::Delim{<:AbstractChar}, source, pos, len, b, code)
     u = bswap(reinterpret(UInt32, d.d))
     while true
         if b != (u & 0x000000ff)
@@ -340,7 +340,7 @@ function tryparsenext(tok, source, pos, len, b, code)::Tuple{Any, Int, UInt8, Re
     return val, pos, b, code
 end
 
-function typeparser(::AbstractConf{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, b, code, pl, options) where {T <: Dates.TimeType}
+@inline function typeparser(::AbstractConf{T}, source::Union{AbstractVector{UInt8}, IO}, pos, len, b, code, pl, options) where {T <: Dates.TimeType}
     fmt = options.dateformat
     df = fmt === nothing ? default_format(T) : fmt
     tokens = df.tokens

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -35,7 +35,7 @@ end
 @enum FloatType FLOAT16 FLOAT32 FLOAT64 BIGFLOAT
 
 # for non SupportedFloat Reals, parse as Float64, then convert
-function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, options) where {T <: Real}
+@inline function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, options) where {T <: Real}
     pos, code, pl, x = typeparser(DefaultConf{Float64}(), source, pos, len, b, code, pl, options)
     return pos, code, pl, T(x)
 end
@@ -67,7 +67,7 @@ function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, opt
     end
 end
 
-function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, options) where {T <: SupportedFloats}
+@inline function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, options) where {T <: SupportedFloats}
     # keep track of starting pos in case of invalid, we can rewind to start of parsing
     startpos = pos
     x = zero(T)
@@ -203,7 +203,7 @@ function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, option
     return pos, code, PosLen(pl.pos, pos - pl.pos), x
 end
 
-function handlef(x::T, f::F) where {T, F}
+@inline function handlef(x::T, f::F) where {T, F}
     if f === nothing
         return x
     else
@@ -225,7 +225,7 @@ getx(x, f) = f === nothing ? x : nothing
 @noinline _parsedigits(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, overflow_invalid::Bool, ndigits::Int, f::F) where {T, IntType, F} =
     parsedigits(conf, source, pos, len, b, code, options, digits, neg, startpos, overflow_invalid, ndigits, f)::Tuple{rettype(T), ReturnCode, Int}
 
-function parsedigits(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, overflow_invalid::Bool=false, ndigits::Int=0, f::F=nothing) where {T, IntType, F}
+@inline function parsedigits(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, overflow_invalid::Bool=false, ndigits::Int=0, f::F=nothing) where {T, IntType, F}
     x = zero(T)
     anydigits = false
     has_groupmark = _has_groupmark(options, code)
@@ -332,7 +332,7 @@ end
 @noinline _parsefrac(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac, overflow_invalid, ndigits, f::F) where {T, IntType, F} =
     parsefrac(conf, source, pos, len, b, code, options, digits, neg, startpos, frac, overflow_invalid, ndigits, f)::Tuple{rettype(T), ReturnCode, Int}
 
-function parsefrac(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac, overflow_invalid, ndigits, f::F) where {T, IntType, F}
+@inline function parsefrac(conf::AbstractConf{T}, source, pos, len, b, code, options, digits::IntType, neg::Bool, startpos, frac, overflow_invalid, ndigits, f::F) where {T, IntType, F}
     x = zero(T)
     parsedanyfrac = false
     FT = FLOAT64
@@ -429,7 +429,7 @@ end
 @noinline _parseexp(conf::AbstractConf{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT, overflow_invalid, ndigits, f::F) where {T, ExpType, F} =
     parseexp(conf, source, pos, len, b, code, options, digits, neg, startpos, frac, exp, negexp, FT, overflow_invalid, ndigits, f)::Tuple{rettype(T), ReturnCode, Int}
 
-function parseexp(conf::AbstractConf{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT, overflow_invalid, ndigits, f::F) where {T, ExpType, F}
+@inline function parseexp(conf::AbstractConf{T}, source, pos, len, b, code, options, digits, neg::Bool, startpos, frac, exp::ExpType, negexp, FT, overflow_invalid, ndigits, f::F) where {T, ExpType, F}
     x = zero(T)
     # note that `b` has already had `b - UInt8('0')` applied to it for parseexp
     while true
@@ -493,12 +493,12 @@ _unsigned(x::BigInt) = x
 _unsigned(x) = unsigned(x)
 
 # No fractional part or exponent, digits in `v` are already scaled
-function noscale(::AbstractConf{T}, v::Integer, neg::Bool, code, ndigits, f::F, ::Options) where {T, F}
+@inline function noscale(::AbstractConf{T}, v::Integer, neg::Bool, code, ndigits, f::F, ::Options) where {T, F}
     return handlef(ifelse(neg, -T(v), T(v)), f), code
 end
 
 # Digits in `v` need to be scaled by `exp`
-function scale(::AbstractConf{T}, FT::FloatType, v, exp, neg, code, ndigits, f::F, ::Options) where {T, F}
+@inline function scale(::AbstractConf{T}, FT::FloatType, v, exp, neg, code, ndigits, f::F, ::Options) where {T, F}
     if T === Float64
         return handlef(__scale(Float64, _unsigned(v), exp, neg), f), code
     elseif T === Float32
@@ -677,7 +677,7 @@ function _scale(::Type{T}, v::V, exp, neg) where {T, V <: BigInt}
     return convert_and_apply_neg(T, x, neg)
 end
 
-function two_prod(a, b)
+@inline function two_prod(a, b)
     x = UInt128(a) * b
     return UInt64(x >> 64), x % UInt64
 end

--- a/src/ints.jl
+++ b/src/ints.jl
@@ -4,7 +4,7 @@ overflowval(::Type{T}) where {T <: Integer} = div(typemax(T) - T(9), T(10))
 # if we eventually support non-base 10
 # overflowval(::Type{T}, base) where {T <: Integer} = div(typemax(T) - base + 1, base)
 
-function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) where {T <: Integer}
+@inline function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) where {T <: Integer}
     x = zero(T)
     neg = false
     has_groupmark = _has_groupmark(opts, code)
@@ -98,13 +98,13 @@ function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) wher
     return pos, code, PosLen(pl.pos, pos - pl.pos), x
 end
 
-function typeparser(::AbstractConf{Number}, source, pos, len, b, code, pl, opts)
+@inline function typeparser(::AbstractConf{Number}, source, pos, len, b, code, pl, opts)
     x = Ref{Number}()
     pos, code = parsenumber(source, pos, len, b, y -> (x[] = y), opts)
     return pos, code, PosLen(pl.pos, pos - pl.pos), isdefined(x, :x) ? x[] : (0::Number)
 end
 
-function parsenumber(source, pos, len, b, f::F, opts=OPTIONS) where {F}
+@inline function parsenumber(source, pos, len, b, f::F, opts=OPTIONS) where {F}
     startpos = pos
     code = startcode = SUCCESS
     # begin parsing

--- a/src/strings.jl
+++ b/src/strings.jl
@@ -2,7 +2,7 @@ isgreedy(::Type{T}) where {T <: AbstractString} = true
 isgreedy(::Type{Symbol}) = true
 isgreedy(T) = false
 
-function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) where {T <: AbstractString}
+@inline function typeparser(::AbstractConf{T}, source, pos, len, b, code, pl, opts) where {T <: AbstractString}
     if quoted(code)
         code |= OK
         return findendquoted(T, source, pos, len, b, code, pl, true, opts.cq, opts.e, opts.flags.stripquoted)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -148,7 +148,7 @@ end
 
 @noinline notsupported() = throw(ArgumentError("Regex matching not supported on this input type"))
 
-function checktoken(source, pos, len, b, token::Token)
+@inline function checktoken(source, pos, len, b, token::Token)
     tok = token.token
     if tok isa UInt8
         check = tok == b
@@ -172,13 +172,13 @@ function checktoken(source, pos, len, b, token::Token)
     end
 end
 
-function checktoken(source, pos, len, b, tok::UInt8)
+@inline function checktoken(source, pos, len, b, tok::UInt8)
     check = tok == b
     check && incr!(source)
     return check, pos + check
 end
 
-function checktoken(source::AbstractVector{UInt8}, pos, len, b, tok::RegexAndMatchData)
+@inline function checktoken(source::AbstractVector{UInt8}, pos, len, b, tok::RegexAndMatchData)
     rc = ccall((:pcre2_match_8, Base.PCRE.PCRE_LIB), Cint,
         (Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Csize_t, UInt32, Ptr{Cvoid}, Ptr{Cvoid}),
         tok.re.regex, source, len, pos - 1, tok.re.match_options, tok.data, Base.PCRE.get_local_match_context())
@@ -187,13 +187,13 @@ function checktoken(source::AbstractVector{UInt8}, pos, len, b, tok::RegexAndMat
     return check, pos + (!check ? 0 : Base.PCRE.substring_length_bynumber(tok.data, 0))
 end
 
-function checktoken(source::AbstractVector{UInt8}, pos, len, b, tok::String)
+@inline function checktoken(source::AbstractVector{UInt8}, pos, len, b, tok::String)
     sz = sizeof(tok)
     check = (pos + sz - 1) <= len && memcmp(pointer(source, pos), pointer(tok), sz)
     return check, pos + (check * sz)
 end
 
-function checktoken(source::IO, pos, len, b, tok::String)
+@inline function checktoken(source::IO, pos, len, b, tok::String)
     bytes = codeunits(tok)
     startpos = pos
     blen = length(bytes)
@@ -450,7 +450,7 @@ _len_bits(::Union{PosLen31,Type{PosLen31}}) = Base.bitcast(Int64, 0x000000007fff
     throw(ArgumentError("length argument to $T ($len) is too large; max length allowed is $(_max_len(T))"))
 
 for T in (:PosLen, :PosLen31)
-    @eval function $T(pos::Integer, len::Integer, ismissing=false, escaped=false)
+    @eval @inline function $T(pos::Integer, len::Integer, ismissing=false, escaped=false)
         pos > _max_pos($T) && postoolarge($T, pos)
         len > _max_len($T) && lentoolarge($T, len)
         @assert pos >= 0
@@ -500,7 +500,7 @@ _unsafe_string(p, len) = ccall(:jl_pchar_to_string, Ref{String}, (Ptr{UInt8}, In
 getstring(source::Union{IO, AbstractVector{UInt8}}, x::Union{PosLen,PosLen31}, e::Token) =
     getstring(source, x, e.token::UInt8)
 
-function getstring(source::Union{IO, AbstractVector{UInt8}}, x::Union{PosLen,PosLen31}, e::UInt8)
+@inline function getstring(source::Union{IO, AbstractVector{UInt8}}, x::Union{PosLen,PosLen31}, e::UInt8)
     x.escapedvalue && return unescape(source, x, e)
     if source isa AbstractVector{UInt8}
         return _unsafe_string(pointer(source, x.pos), x.len)


### PR DESCRIPTION
These were dropped in https://github.com/JuliaData/Parsers.jl/pull/196/commits/894a556064966f5a4588c8bb6e94f7a75da3b29d / #196 

And this may be responsible for a significant drop in performance for parsing ints and floats (but TBC)