### PR TITLE
Fix BigFloat MPFR parsing overread

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -40,30 +40,85 @@ function typeparser(conf::AbstractConf{T}, source, pos, len, b, code, pl, option
     return pos, code, pl, T(x)
 end
 
+function _copy_nulterminated(source::AbstractVector{UInt8}, pos, len)
+    vlen = max(0, len)
+    buf = Vector{UInt8}(undef, vlen + 1)
+    vlen > 0 && copyto!(buf, 1, source, pos, vlen)
+    @inbounds buf[vlen + 1] = 0x00
+    return buf
+end
+
+@inline _nulterminated(source, len) = false
+@inline _nulterminated(source::String, len) = len == sizeof(source)
+@inline _nulterminated(source::Base.CodeUnits{UInt8,String}, len) = len == length(source)
+@inline function _nulterminated(source::AbstractVector{UInt8}, len)
+    return len < length(source) && @inbounds(source[len + 1]) == 0x00
+end
+
+function _bigfloat_buffer(source::AbstractVector{UInt8}, pos, len, b, code, options)
+    _, _, pl, _ = typeparser(DefaultConf{String}(), source, pos, len, b, code, poslen(pos, 0), options)
+    return _copy_nulterminated(source, pl.pos, pl.len)
+end
+
+_bigfloat_buffer(source::AbstractString, pos, len, b, code, options) =
+    _bigfloat_buffer(codeunits(source), pos, len, b, code, options)
+
+function _bigfloat_buffer(source::IO, pos, len, b, code, options)
+    _, _, pl, _ = typeparser(DefaultConf{String}(), source, pos, len, b, code, poslen(pos, 0), options)
+    vlen = max(0, pl.len)
+    buf = Vector{UInt8}(undef, vlen + 1)
+    fastseek!(source, pl.pos - 1)
+    readbytes!(source, buf, vlen)
+    @inbounds buf[vlen + 1] = 0x00
+    fastseek!(source, pos - 1)
+    return buf
+end
+
+@inline function _mpfr_strtofr(z, ptr, endptr, base, rounding)
+    return ccall((:mpfr_strtofr, :libmpfr), Int32, (Ref{BigFloat}, Cstring, Ref{Ptr{UInt8}}, Int32, Base.MPFR.MPFRRoundingMode), z, ptr, endptr, base, rounding)
+end
+
+@inline function _finish_bigfloat(source, pos, code, pl, z, ptr, base, rounding)
+    endptr = Ref{Ptr{UInt8}}()
+    err = _mpfr_strtofr(z, ptr, endptr, base, rounding)
+    code |= endptr[] == ptr ? INVALID : OK
+    pos += Int(endptr[] - ptr)
+    source isa IO && fastseek!(source, pos - 1)
+    return pos, code, PosLen(pl.pos, max(0, pos - pl.pos)), z
+end
+
 function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, options)
     base = 0
     rounding = Base.MPFR.ROUNDING_MODE[]
     z = BigFloat(precision=Base.MPFR.DEFAULT_PRECISION[])
-    if source isa AbstractVector{UInt8} || source isa String
-        str = source
-        strpos = pos
+    if _nulterminated(source, len)
+        GC.@preserve source begin
+            return _finish_bigfloat(source, pos, code, pl, z, pointer(source, pos), base, rounding)
+        end
+    elseif source isa Vector{UInt8}
+        _, _, strpl, _ = typeparser(DefaultConf{String}(), source, pos, len, b, code, poslen(pos, 0), options)
+        nulpos = strpl.pos + strpl.len
+        if nulpos <= length(source)
+            @inbounds byte = source[nulpos]
+            @inbounds source[nulpos] = 0x00
+            try
+                GC.@preserve source begin
+                    return _finish_bigfloat(source, pos, code, pl, z, pointer(source, pos), base, rounding)
+                end
+            finally
+                @inbounds source[nulpos] = byte
+            end
+        else
+            buf = _copy_nulterminated(source, strpl.pos, strpl.len)
+            GC.@preserve buf begin
+                return _finish_bigfloat(source, pos, code, pl, z, pointer(buf), base, rounding)
+            end
+        end
     else
-        _, _, _pl, _ = typeparser(String, source, pos, len, b, code, pl, options)
-        _pos = position(source)
-        vpos, vlen = _pl.pos, _pl.len
-        fastseek!(source, vpos - 1)
-        str = Base.StringVector(vlen)
-        strpos = 1
-        readbytes!(source, str, vlen)
-        fastseek!(source, _pos) # reset IO to earlier position
-    end
-    GC.@preserve str begin
-        ptr = pointer(str, strpos)
-        endptr = Ref{Ptr{UInt8}}()
-        err = ccall((:mpfr_strtofr, :libmpfr), Int32, (Ref{BigFloat}, Cstring, Ref{Ptr{UInt8}}, Int32, Base.MPFR.MPFRRoundingMode), z, ptr, endptr, base, rounding)
-        code |= endptr[] == ptr ? INVALID : OK
-        pos += Int(endptr[] - ptr)
-        return pos, code, PosLen(pl.pos, max(0, pos - pl.pos)), z
+        buf = _bigfloat_buffer(source, pos, len, b, code, options)
+        GC.@preserve buf begin
+            return _finish_bigfloat(source, pos, code, pl, z, pointer(buf), base, rounding)
+        end
     end
 end
 

--- a/src/floats.jl
+++ b/src/floats.jl
@@ -48,11 +48,24 @@ function _copy_nulterminated(source::AbstractVector{UInt8}, pos, len)
     return buf
 end
 
+@inline _contiguous(source) = false
+@inline _contiguous(source::StridedVector{UInt8}) = stride(source, 1) == 1
+@inline _writable_contiguous(source) = false
+@inline _writable_contiguous(source::Vector{UInt8}) = true
+@inline _writable_contiguous(source::SubArray{UInt8,1}) =
+    parent(source) isa Vector{UInt8} && _contiguous(source)
+
 @inline _nulterminated(source, len) = false
 @inline _nulterminated(source::String, len) = len == sizeof(source)
 @inline _nulterminated(source::Base.CodeUnits{UInt8,String}, len) = len == length(source)
 @inline function _nulterminated(source::AbstractVector{UInt8}, len)
-    return len < length(source) && @inbounds(source[len + 1]) == 0x00
+    return _contiguous(source) && len < length(source) && @inbounds(source[len + 1]) == 0x00
+end
+
+@inline function _ends_on_delimiter(source::AbstractVector{UInt8}, len, options)
+    0 < len <= length(source) || return false
+    @inbounds b = source[len]
+    return b == UInt8('\n') || b == UInt8('\r') || (options.flags.checkdelim && options.delim == b)
 end
 
 function _bigfloat_buffer(source::AbstractVector{UInt8}, pos, len, b, code, options)
@@ -95,9 +108,13 @@ function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, opt
         GC.@preserve source begin
             return _finish_bigfloat(source, pos, code, pl, z, pointer(source, pos), base, rounding)
         end
-    elseif source isa Vector{UInt8}
-        _, _, strpl, _ = typeparser(DefaultConf{String}(), source, pos, len, b, code, poslen(pos, 0), options)
-        nulpos = strpl.pos + strpl.len
+    elseif _writable_contiguous(source)
+        nulpos = if _ends_on_delimiter(source, len, options)
+            len
+        else
+            _, _, strpl, _ = typeparser(DefaultConf{String}(), source, pos, len, b, code, poslen(pos, 0), options)
+            strpl.pos + strpl.len
+        end
         if nulpos <= length(source)
             @inbounds byte = source[nulpos]
             @inbounds source[nulpos] = 0x00
@@ -109,6 +126,7 @@ function typeparser(::AbstractConf{BigFloat}, source, pos, len, b, code, pl, opt
                 @inbounds source[nulpos] = byte
             end
         else
+            _, _, strpl, _ = typeparser(DefaultConf{String}(), source, pos, len, b, code, poslen(pos, 0), options)
             buf = _copy_nulterminated(source, strpl.pos, strpl.len)
             GC.@preserve buf begin
                 return _finish_bigfloat(source, pos, code, pl, z, pointer(buf), base, rounding)

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -480,6 +480,24 @@ end
 end
 
 @testset "BigFloats" begin
+    res = Parsers.xparse(BigFloat, Vector(codeunits("1")), 1, 1)
+    @test res.val == BigFloat(1)
+    @test res.code == OK
+    @test res.tlen == 1
+
+    @test Parsers.parse(BigFloat, Vector(codeunits("12")), Parsers.Options(), 1, 1) == BigFloat(1)
+    @test Parsers.parse(BigFloat, codeunits("12"), Parsers.Options(), 1, 1) == BigFloat(1)
+
+    res = Parsers.xparse(BigFloat, IOBuffer("1,"), 1, 2)
+    @test res.val == BigFloat(1)
+    @test res.code == (OK | DELIMITED)
+    @test res.tlen == 2
+
+    res = Parsers.xparse(BigFloat, IOBuffer("1a,"), 1, 3)
+    @test res.val == BigFloat(1)
+    @test res.code == (OK | DELIMITED | INVALID_DELIMITER)
+    @test res.tlen == 3
+
     @test Parsers.parse(BigFloat, "1.7976931348623157e308") == Base.parse(BigFloat, "1.7976931348623157e308")
     @test Parsers.parse(BigFloat, "-1.7976931348623157e308") == Base.parse(BigFloat, "-1.7976931348623157e308")
     # next float64 - too large

--- a/test/floats.jl
+++ b/test/floats.jl
@@ -488,6 +488,19 @@ end
     @test Parsers.parse(BigFloat, Vector(codeunits("12")), Parsers.Options(), 1, 1) == BigFloat(1)
     @test Parsers.parse(BigFloat, codeunits("12"), Parsers.Options(), 1, 1) == BigFloat(1)
 
+    bytes = Vector(codeunits("xx123,yy"))
+    res = Parsers.xparse(BigFloat, @view(bytes[3:6]), 1, 4)
+    @test res.val == BigFloat(123)
+    @test res.code == (OK | DELIMITED)
+    @test res.tlen == 4
+    @test String(bytes) == "xx123,yy"
+
+    bytes = Vector(codeunits("1x2"))
+    res = Parsers.xparse(BigFloat, @view(bytes[1:2:3]), 1, 2)
+    @test res.val == BigFloat(12)
+    @test res.code == OK
+    @test res.tlen == 2
+
     res = Parsers.xparse(BigFloat, IOBuffer("1,"), 1, 2)
     @test res.val == BigFloat(1)
     @test res.code == (OK | DELIMITED)


### PR DESCRIPTION
## Summary
- pass `mpfr_strtofr` input that is explicitly NUL-terminated within Parsers' logical parse boundary
- preserve the existing zero-copy path for sources that are already safely NUL-terminated
- use a temporary NUL/restore fast path for writable contiguous `Vector{UInt8}` buffers and contiguous `SubArray` views backed by `Vector{UInt8}`
- fall back to a copied NUL-terminated candidate buffer for immutable, IO, or non-contiguous sources
- add regressions for bounded vector/codeunits parsing, IO BigFloat parsing, and byte-vector views

## Background
Fixes #189.

This is intended as a more bounded/perf-conscious follow-up to #193. The earlier PR fixed the missing terminator by copying through `String`, but that can copy more than the candidate field and does not preserve the common no-copy byte-buffer path.

## Performance notes
Benchmarked with Chairmarks.jl on Julia 1.12.5. Representative hot paths stayed at the same allocation counts as `main`:

- `Parsers.parse(BigFloat, str)`: 225.0 ns on `main`, 220.2 ns patched; 2 allocs both
- `xparse(BigFloat, codeunits(str))`: 250.0 ns on `main`, 255.8 ns patched; 3 allocs both
- `xparse` on NUL-terminated `Vector`: 234.2 ns on `main`, 245.4 ns patched; 3 allocs both
- delimited `Vector`, long tail: 276.0 ns on `main`, 271.9 ns patched; 3 allocs both
- contiguous `SubArray` view: 252.8 ns on `main` versus 274.9 ns patched; 3 allocs both, with the patched path bounded by the temporary NUL rather than MPFR reading through the parent buffer

## Testing
- `julia --project=. -e 'using Parsers, Test; import Parsers: INVALID, OK, SENTINEL, QUOTED, DELIMITED, NEWLINE, EOF, INVALID_QUOTED_FIELD, INVALID_DELIMITER, OVERFLOW, ESCAPED_STRING, SPECIAL_VALUE, INEXACT; include("test/floats.jl")'` on Julia 1.12.5: 2650/2650
- `julia --project=. -e 'using Pkg; Pkg.test(; coverage=false)'` on Julia 1.12.5: 566038/566038
- `julia +1.11 --project=. -e 'using Pkg; Pkg.instantiate(); using Parsers, Test; import Parsers: INVALID, OK, SENTINEL, QUOTED, DELIMITED, NEWLINE, EOF, INVALID_QUOTED_FIELD, INVALID_DELIMITER, OVERFLOW, ESCAPED_STRING, SPECIAL_VALUE, INEXACT; include("test/floats.jl")'`: 2650/2650