### PR TITLE
Reduce parser precompile workload

### DIFF
--- a/src/floats.jl
+++ b/src/floats.jl
@@ -312,7 +312,7 @@ function parsedigits(conf::AbstractConf{T}, source, pos, len, b, code, options, 
         while true
             if b <= 0x09
                 if overflows(IntType) && digits > overflowval(IntType)
-                    return _parsedigits(conf, source, pos, len, b + UInt8('0'), code, options, _widen(digits), neg, startpos, overflow_invalid, ndigits, f)
+                    return _parsedigits(conf, source, pos, len, b + UInt8('0'), code, options, Base.inferencebarrier(_widen(digits)), neg, startpos, overflow_invalid, ndigits, f)
                 elseif ndigits > maxdigits(T)
                     # if input is way too big, just bail
                     fastseek!(source, startpos - 1)
@@ -392,7 +392,7 @@ function parsedigits(conf::AbstractConf{T}, source, pos, len, b, code, options, 
     # now we parse any digits following decimal point (if any); start `frac` at UInt64(0)
     # `digits` still receives any fractional digits, `frac` just keeps track of how many digits
     # were parsed to combine with any "e123" exponent numbers to determine final exponent value
-    (overflows(IntType) && digits > overflowval(IntType)) && (digits = _widen(digits))
+    (overflows(IntType) && digits > overflowval(IntType)) && (digits = Base.inferencebarrier(_widen(digits)))
     x, code, pos = parsefrac(conf, source, pos, len, b, code, options, digits, neg, startpos, UInt64(0), overflow_invalid, ndigits, f)
 
 @label done
@@ -434,7 +434,7 @@ function parsefrac(conf::AbstractConf{T}, source, pos, len, b, code, options, di
             b = peekbyte(source, pos) - UInt8('0')
             b > 0x09 && break
             if overflows(IntType) && digits > overflowval(IntType)
-                return _parsefrac(conf, source, pos, len, b + UInt8('0'), code, options, _widen(digits), neg, startpos, frac, overflow_invalid, ndigits, f)
+                return _parsefrac(conf, source, pos, len, b + UInt8('0'), code, options, Base.inferencebarrier(_widen(digits)), neg, startpos, frac, overflow_invalid, ndigits, f)
             end
         end
         b += UInt8('0')
@@ -535,7 +535,7 @@ function parseexp(conf::AbstractConf{T}, source, pos, len, b, code, options, dig
             @goto done
         end
         if overflows(ExpType) && exp > overflowval(ExpType)
-            return _parseexp(conf, source, pos, len, b, code, options, digits, neg, startpos, frac, _widen(exp), negexp, FT, overflow_invalid, ndigits, f)
+            return _parseexp(conf, source, pos, len, b, code, options, digits, neg, startpos, frac, Base.inferencebarrier(_widen(exp)), negexp, FT, overflow_invalid, ndigits, f)
         end
     end
 @label done

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -5,20 +5,22 @@ using PrecompileTools
     # precompile file and potentially make loading faster.
     options = Parsers.Options()
     pos = 1
-    val = "123"
-    len = length(val)
+    int_val = "123"
+    float_val = "123.45"
+    bool_val = "true"
     @compile_workload begin
         # all calls in this block will be precompiled, regardless of whether
         # they belong to your package or not (on Julia 1.8 and higher)
-        for T in (String, Int32, Int64, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool)
+        for (T, val) in ((String, int_val), (Int32, int_val), (Int64, int_val), (Float64, float_val), (Bool, bool_val))
+            len = length(val)
             for buf in (codeunits(val), Vector(codeunits(val)))
                 Parsers.xparse(T, buf, pos, len, options)
                 Parsers.xparse(T, buf, pos, len, options, Any)
             end
         end
 
-        for T in (Int32, Int64, Float64, BigFloat, Dates.Date, Dates.DateTime, Dates.Time, Bool)
-            for buf in (val, SubString(val, 1:3), Vector(codeunits(val)), view(Vector(codeunits(val)), 1:3))
+        for (T, val) in ((Int32, int_val), (Int64, int_val), (Float64, float_val), (Bool, bool_val))
+            for buf in (val, Vector(codeunits(val)))
                 try
                     Parsers.parse(T, buf, options)
                 catch


### PR DESCRIPTION
## Summary
- Narrow the PrecompileTools workload to core string, integer, Float64, and Bool parse/xparse cases.
- Stop precompiling BigFloat, Dates, SubString, and view inputs in the default workload.
- Add inference barriers around rare float widening branches so simple Float64 precompile avoids eagerly inferring the UInt128/BigInt overflow tree.

## Measurements
Measured on Julia 1.12.5 in fresh temp projects/depots with dependency caches available:

- Original workload: ~4.96s Parsers precompile, 5.5 MB dylib, 1142 Julia symbols.
- This patch: ~2.54s Parsers precompile, 2.6 MB dylib, 388 Julia symbols.

First-call latency after precompile:

- parse(Int64, "123"): ~16.8 ms
- parse(Float64, "123.45"): ~18.3 ms
- parse(Bool, "true"): ~16.4 ms
- xparse(Float64, codeunits("123.45"), ...): ~2.0 ms
- xparse(Float64, Vector(...), ..., Any): ~2.0 ms

## Tests
- julia --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'
- julia +1.6 --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); using Parsers; @assert Parsers.parse(Float64, "123.45") == 123.45; @assert Parsers.xparse(Float64, Vector(codeunits("123.45")), 1, 6, Parsers.Options()).val == 123.45; println("julia ", VERSION, " focused checks ok")'
- git diff --check

Co-authored by Codex
