### PR TITLE
Explain the getstring escape argument

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -492,6 +492,10 @@ When calling `Parsers.xparse` with a `String` type argument, a `Parsers.Result{P
 
 If the actual parsed `String` _is_ needed, however, you can pass your source and the `res.val::PosLen` to `Parsers.getstring`
 to get the actual parsed `String` value.
+
+`e` is the escape character byte used by the matching `Parsers.xparse` call. Pass the same value as its `escapechar`
+option, or `options.e` when an explicit `Parsers.Options` object was used. `e` is ignored when `poslen.escapedvalue`
+is `false`, so a byte that does not occur in the value, such as `0x00`, is also valid when no escape characters were parsed.
 """
 function getstring end
 


### PR DESCRIPTION
## Summary

- explain that the third `getstring` argument is the escape character byte used by `xparse`
- show when to pass `options.e`
- clarify why `0x00` is safe when the parsed `PosLen` is not escaped

## Validation

- loaded and inspected the updated docstring on Julia 1.12.6
- full `Pkg.test()` passed on Julia 1.12.6

Fixes #119

Co-authored by Codex